### PR TITLE
Mq2 declared variables patch

### DIFF
--- a/bardBot.mac
+++ b/bardBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   BardBot v1.28
+| 									   BardBot v1.29
 | 									Written By: Devestator
 | 													
 | 													
@@ -19,6 +19,9 @@
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
 |  PLUGIN: MQ2MoveUtils
+| 
+| v1.29 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.27 Update Notes
 |  -Added a check to avoid singing songs when CastWhileInvis is false.
@@ -164,21 +167,17 @@ Sub main(string iniNameStr)
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.60
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	/varset debugLvl 0
 	
 	/call EchoLog "BardBot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName bardBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName bardBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName bardBotSettings.ini
-		}
+		/varset iniName bardBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -195,7 +194,7 @@ Sub main(string iniNameStr)
 	/declare oocSongsCount							int local 0
 	:mainLoop
 		/doevents
-		/if (${Me.Aura[1].Equal[${auraSong}]} || ${Me.Aura[2].Equal[${auraSong}]} || ${Me.Aura[1].Equal[${auraText}]} || ${Me.Aura[2].Equal[${auraText}]}) {
+		/if (${Me.Aura[1].Name.Equal[${auraSong}]} || ${Me.Aura[2].Name.Equal[${auraSong}]} || ${Me.Aura[1].Name.Equal[${auraText}]} || ${Me.Aura[2].Name.Equal[${auraText}]}) {
 			| Work around for MQ2 aura bug
 		} else {
 			/if (${auraSong.NotEqual[NULL]} && ${auraGem} && (${castWhileInvis} || !${Me.Invis})) /call CastSong "${auraSong}" ${auraGem}
@@ -253,7 +252,7 @@ Sub AfterDeath
 /return
 
 Sub BardCombatCheck(bool AddCheck)
-	/if (!${Defined[AddCheck]}) /declare AddCheck				bool local TRUE
+	/if (${AddCheck} == NULL) /varset AddCheck TRUE
 	/if (${AddCheck}) /call CheckForAdds ${campRadius} ${Me.ID} false true
 	/if (!${inCombat} && (${lTargCount} > 0 || ${Me.CombatState.Equal[Combat]})) {
 		/if (${Me.Sitting}) /stand
@@ -274,7 +273,7 @@ Sub BardCombatCheck(bool AddCheck)
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -371,10 +370,10 @@ Sub CastCall
 /return
 
 Sub CastSong(string songName, int songGem, int maxTries, bool endSong, string onCallRoutine, bool immediateInterrupt)
-	/if (!${Defined[songGem]} || !${songGem}) /return
-	/if (!${Defined[maxTries]}) /declare maxTries			int local 2
-	/if (!${Defined[endSong]}) /declare endSong				bool local TRUE
-	/if (!${Defined[immediateInterrupt]}) /declare immediateInterrupt			bool local FALSE
+	/if (${songGem} == NULL || !${songGem}) /return
+	/if (${maxTries} == NULL) /varset maxTries 2
+	/if (${endSong} == NULL) /varset endSong TRUE
+	/if (${immediateInterrupt} == NULL) /varset immediateInterrupt FALSE
 	/declare castTimer					timer local 0s
 	/declare resAttempts				int local 1
 	/declare castTimeout				timer local 0s
@@ -845,8 +844,8 @@ Sub Mez(int mezTargID)
 /return
 
 Sub MezList(string Action, int AddID, string setTimer) 
-	/if (!${Defined[Action]}) /declare Action				string local UPDATE
-	/if (!${Defined[setTimer]}) /declare setTimer		string local ${Spell[${singleMez}].Duration.Float}s
+	/if (${Action.Equal[NULL]}) /varset Action UPDATE
+	/if (${setTimer.Equal[NULL]}) /varset setTimer ${Spell[${singleMez}].Duration.Float}s
 	/declare mlArray							int local 0
 	/declare hReturn							string local FALSE
 	
@@ -953,7 +952,7 @@ Sub MezTimerCheck(int mezTargID)
 /return FALSE
 
 Sub MezVerify(int vID)
-	/if (!${Defined[vID]}) /return TRUE
+	/if (${vID} == NULL) /return TRUE
 	/declare retValue					bool local TRUE
 	
 	/call timer attempts ${vID}

--- a/beastlordBot.mac
+++ b/beastlordBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   BeastlordBot v1.09
+| 									   BeastlordBot v1.11
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.11 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.09 Update Notes
 |  -Corrected a typo that resulted in a crash error after being rezzed
@@ -63,27 +66,23 @@
 #event FDFail "#1# has fallen to the ground."
 
 Sub Main(string iniNameStr)
-	/declare meVersion		float outer 1.09
+	/declare meVersion		float outer 1.11
 	/declare myName				string outer beastlordbot
 	/declare myClass			string outer BST
 
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.60
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "Beastlordbot Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName beastlordBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName beastlordBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName beastlordBotSettings.ini
-		}
+		/varset iniName beastlordBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -225,7 +224,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -332,7 +331,7 @@ Sub Burn
 /return
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local CheckHealTargHPs
+	/if (${hpWatch.Equal[NULL]}) /varset hpWatch CheckHealTargHPs
 	
 	/squelch /target clear
 	/delay 1s !${Target.ID}
@@ -735,7 +734,7 @@ Sub ShrinkCheck(string charName)
 	/declare shrinkNeeded						bool local FALSE
 	/declare groupHasPets						bool local FALSE
 	/declare shrinkItem							string local FALSE
-	/if (!${Defined[charName]}) {
+	/if (${charName.Equal[NULL]}) {
 		/if (${useGroupShrink} && (${Me.Book[Tiny Terror]} || ${Me.AltAbilityReady[Group Shrink]})) {
 			:castGroupShrink
 				/call CombatCheck
@@ -847,7 +846,7 @@ Sub ShrinkCheck(string charName)
 /return NULL
 
 Sub TrackHoT(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -880,7 +879,7 @@ Sub TrackHoT(int playerID, int SpellID)
 /return FALSE
 
 Sub PetCheck(bool allowSummon)
-	/if (!${Defined[allowSummon]}) /declare allowSummon					bool local TRUE
+	/if (${allowSummon} == NULL) /varset allowSummon TRUE
 	/declare shrinkItemName				string local NULL
 	/declare shrinkCastCount			int local 0
 	

--- a/berserkerBot.mac
+++ b/berserkerBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   BerserkerBot v1.09
+| 									   BerserkerBot v1.10
 | 									 Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.10 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.09 Update Notes
 |  -Converted to common target routine
@@ -59,27 +62,23 @@
 |#include berserkerBotSettings.ini
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 1.09
+	/declare meVersion									float outer 1.10
 	/declare myName											string outer berserkerbot
 	/declare myClass										string outer BER
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.62
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "BerserkerBot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName berserkerBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName berserkerBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName berserkerBotSettings.ini
-		}
+		/varset iniName berserkerBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -134,7 +133,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 	/declare mReturn		int local 0
@@ -557,9 +556,9 @@ Sub BurnRoutine
 /return
 
 
-Sub BurnSetUsed(burnSet)
+Sub BurnSetUsed(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	
@@ -575,9 +574,9 @@ Sub BurnSetUsed(burnSet)
 	/next bSetArray	
 /return FALSE
 
-Sub BurnSetReady(burnSet)
+Sub BurnSetReady(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	/declare tAbi								string local NULL

--- a/clericBot2.mac
+++ b/clericBot2.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 							   Premium ClericBot v2.26
+| 							   Premium ClericBot v2.27
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs
 |  PLUGIN: MQ2Exchange
+| 
+| v2.27 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v2.26 Update Notes
 |  -Corrected typo on Dimnuitive Companion AA cast, it should not correctly use it to shrink pets if configure to.
@@ -139,27 +142,23 @@
 |#include clericBotSettings.ini
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 2.26
+	/declare meVersion									float outer 2.27
 	/declare myName											string outer clericbot2
 	/declare myClass										string outer CLR
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.62
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "ClericBot2 v${meVersion} Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName clericBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName clericBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName clericBotSettings.ini
-		}
+		/varset iniName clericBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -222,7 +221,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -352,9 +351,9 @@ Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
 /return ${hMsg}
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[healTargID]} || !${healTargID}) /return
+	/if (${healTargID} == NULL || !${healTargID}) /return
 	/declare sMaxTry				int local ${resistTries}
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local EmergencyHeal
+	/if (${hpWatch.Equal[NULL]}) /varset hpWatch EmergencyHeal
 	
 	/if (${Me.Casting.ID} && ${allowInterrupt}) /call Interrupt
 	/varset currHealID ${Spell[${healSpell[${healNum}]}].ID}
@@ -892,7 +891,7 @@ Sub LoadSettings
 /return
 
 Sub CureCheck(bool ignoreTimer)
-	/if (${cureCheckTimer} && (!${Defined[ignoreTimer]} || !${ignoreTimer})) /return ABORT_TIMER
+	/if (${cureCheckTimer} && (${ignoreTimer} == NULL || !${ignoreTimer})) /return ABORT_TIMER
 	/if (${cureOOCOnly} && ${inCombat}) /return ABORT_COMBAT
 	/declare grpArray					int local 0
 	/declare bArray						int local 0
@@ -1010,7 +1009,7 @@ Sub HealCheck(bool secondaryCall)
 	/if ((${useEpicBalance} || ${useAABalance})) /call EpicAACheck
 	
 	/if (!${healCount}) /return
-	/if (!${Defined[secondaryCall]}) /declare secondaryCall		bool local FALSE
+	/if (${secondaryCall} == NULL) /varset secondaryCall FALSE
 	/declare hInt					int local 0
 	/declare gPets				bool local false
 	/declare grpArray			int local 0
@@ -1285,7 +1284,7 @@ Sub HealCheck(bool secondaryCall)
 /return
 
 Sub SecondaryHealCheck(bool gPets)
-	/if (!${Defined[gPets]}) /declare gPets			bool local FALSE
+	/if (${gPets} == NULL) /declare gPets FALSE
 	/declare hInt					int local 0
 	/declare groupAvgHP		int local 0
 	/declare avgCount			int local 0
@@ -1585,7 +1584,7 @@ Sub RezTarget(int rezTargID, bool ignoreTimer)
 /return UNKNOWN
 
 Sub TrackRez(int rezTargID, bool addTrack)
-	/if (!${Defined[addTrack]}) /declare addTrack				bool local FALSE
+	/if (${addTrack} == NULL) /varset addTrack FALSE
 	
 	/if (!${Defined[rezTrack${rezTargID}]}) /declare rezTrack${rezTargID}			timer outer 0s
 	/if (${addTrack}) {
@@ -1601,7 +1600,7 @@ Sub TrackRez(int rezTargID, bool addTrack)
 /return
 
 Sub TrackPromise(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -1622,7 +1621,7 @@ Sub TrackPromise(int playerID, int SpellID)
 /return FALSE
 
 Sub TrackHoT(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	

--- a/devCast.inc
+++ b/devCast.inc
@@ -1,10 +1,13 @@
 | ========================================================================================================
-| 							 devCast.inc v1.05
+| 							 devCast.inc v1.06
 |     					Written By: Devestator
 | 
 | 
 | Description:
 |  Include file to handle casting without the use of MQ2Cast
+| 
+| v1.06 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.05 Update Notes
 |  -Corrected white mq2chatwnd spam when casting an item
@@ -61,11 +64,11 @@ Sub MQ2CastInit
 /return
 
 Sub devCastInit(bool standAloneRun)
-	/if (!${Defined[standAloneRun]}) /declare standAloneRun bool local FALSE
-	/declare devCastVersion								float outer 1.05
+	/if (${standAloneRun} == NULL) /varset standAloneRun FALSE
+	/declare devCastVersion								float outer 1.06
 	/declare CastResult										string outer CAST_INIT
 	/declare devCastCasting								bool outer FALSE
-	/declare MQ2CastSpellRoutinesVer			float outer 1.03
+	| /declare MQ2CastSpellRoutinesVer			float outer 1.03
 	/declare devCastStandAlone						bool outer ${standAloneRun}
 	
 	/if (!${devCastStandAlone}) /call EchoLog "\awInitializing devCast.inc \agv${devCastVersion}" FALSE
@@ -143,8 +146,7 @@ Sub Cast(string castName, string castSlot, timer castMaxTryTime, string castCall
 	/call Cast_GetSpellRank "${castName}"
 	/varset baseRank ${Macro.Return}
 	
-	/if (!${Defined[castSlot]} || (!${Select[${castSlot},ALT,ITEM,ABILITY,DISC]} && !${castSlot.Find[GEM]})) {
-		/if (!${Defined[castSlot]}) /declare castSlot	string local NULL
+	/if (${castSlot.Equal[NULL]} || (!${Select[${castSlot},ALT,ITEM,ABILITY,DISC]} && !${castSlot.Find[GEM]})) {
 		/varset mySpell ${castName}
 		/if (${Me.AltAbility[${castName}]}) {
 			/varset castSlot ALT
@@ -197,7 +199,7 @@ Sub Cast(string castName, string castSlot, timer castMaxTryTime, string castCall
 	}
 
 
-	/if (!${Defined[castMaxTryTime]}) /declare castMaxTryTime	timer local ${defaultMaxWaitTime}
+	/if (${castMaxTryTime} == NULL) /varset castMaxTryTime ${defaultMaxWaitTime}
 	/if (!${castMaxTryTime}) /varset castMaxTryTime ${defaultMaxWaitTime}
 	
 	/if (${castSlot.Find[GEM]}) {
@@ -277,7 +279,6 @@ Sub Cast(string castName, string castSlot, timer castMaxTryTime, string castCall
 		}
 	}
 
-	/if (!${Defined[castCallRoutine]}) /declare castCallRoutine		string local Cast_DefaultCall
 	/if (!${castCallRoutine.Length} || ${castCallRoutine.Equal[NULL]}) /varset castCallRoutine Cast_DefaultCall
 	
 	/varset devCastCasting TRUE

--- a/devCommonPremium.inc
+++ b/devCommonPremium.inc
@@ -1,6 +1,6 @@
 #define HIGHERDEBUG /devecholog
 | ========================================================================================================
-| 					 devCommonPremium.inc v2.50
+| 					 devCommonPremium.inc v2.51
 |     					Written By: Devestator
 | 
 | 
@@ -8,6 +8,9 @@
 |  A compilation of common subs used in multiple macros by Devestator.
 |  Must /call CommonInit before using any subroutines in this include.
 |  Call CommonLoad after you load all settings for your macro.
+| 
+| v2.51 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v2.50 Update Notes
 |  -Update respite discs
@@ -77,7 +80,6 @@
 
 #turbo 80
 
-|#include devMQ2Cast_Spell_Routines.inc
 #include devCast.inc
 #include devMovementPremium.inc
 #include devLoot.inc
@@ -125,10 +127,10 @@
 
 Sub CommonInit
 	/squelch /alias /devecholog /call EchoLog
-	/declare devCommonVer								float outer 2.50
-	/declare reqMovementCommon						float outer 1.73
-	/declare reqCastCommon								float outer 1.04
-	/declare reqPullCommon								float outer 1.06
+	/declare devCommonVer								float outer 2.51
+	/declare reqMovementCommon						float outer 1.74
+	/declare reqCastCommon								float outer 1.06
+	/declare reqPullCommon								float outer 1.10
 	/squelch /plugin MQ2Debuffs
 	/squelch /plugin MQ2Exchange
 	/squelch /plugin MQ2CEcho
@@ -139,22 +141,22 @@ Sub CommonInit
 	| =====================================================================
 	| Declare supported bot versions
 	| =====================================================================	
-	/declare bardbot									float outer 1.13
-	/declare beastlordbot								float outer 1.01
-	/declare berserkerbot								float outer 1.04
-	/declare clericbot2									float outer 2.00
-	/declare druidbot									float outer 1.04
-	/declare enchanterbot								float outer 1.08
-	/declare magebot2									float outer 4.00
-	/declare monkbot									float outer 1.07
-	/declare necrobot									float outer 1.03
-	/declare paladinbot									float outer 1.00
-	/declare rangerbot									float outer 1.12
-	/declare roguebot									float outer 1.00
-	/declare shamanbot									float outer 1.05
-	/declare skbot2										float outer 2.00
-	/declare warriorbot									float outer 1.00
-	/declare wizardbot									float outer 1.03
+	/declare bardbot									float outer 1.29
+	/declare beastlordbot								float outer 1.11
+	/declare berserkerbot								float outer 1.10
+	/declare clericbot2									float outer 2.27
+	/declare druidbot									float outer 1.15
+	/declare enchanterbot								float outer 1.23
+	/declare magebot2									float outer 4.18
+	/declare monkbot									float outer 1.24
+	/declare necrobot									float outer 1.17
+	/declare paladinbot									float outer 1.08
+	/declare rangerbot									float outer 1.13
+	/declare roguebot									float outer 1.25
+	/declare shamanbot									float outer 1.25
+	/declare skbot2										float outer 2.16
+	/declare warriorbot									float outer 1.11
+	/declare wizardbot									float outer 1.13
 	
 	| =====================================================================
 	| Declare general variables
@@ -240,6 +242,7 @@ Sub CommonInit
 		/squelch /alias /myecho /echo
 		/varset colorEcho FALSE
 	}
+	
 	/if (${isMMOBugs} && ${Me.AltAbility[Eyes Wide Open]}) {
 		/varset maxXTargets ${Me.MaxXTarget}
 	} else {
@@ -961,7 +964,7 @@ Sub CommonLoad
 /return
 
 Sub CombatCheck(bool AddCheck)
-	/if (!${Defined[AddCheck]}) /declare AddCheck				bool local TRUE
+	/if (${AddCheck} == NULL) /varset AddCheck TRUE
 	/if (${AddCheck}) /call CheckForAdds ${campRadius} ${Me.ID} FALSE TRUE
 	/if (!${inCombat} && (${lTargCount} > 0 || ${Me.CombatState.Equal[Combat]})) {
 		/varset inCombat TRUE
@@ -998,11 +1001,11 @@ Sub CommonCombatRoutines(string callRoutine,bool AllowCombatBuff,bool AllowDebuf
 	
 	/if (${Me.State.Equal[HOVER]}) /call Event_died
 	
-	/if (!${Defined[AllowCombatBuff]}) /declare AllowCombatBuff				bool local TRUE
-	/if (!${Defined[AllowDebuff]}) /declare AllowDebuff								bool local TRUE
-	/if (!${Defined[AllowAddCleanup]}) /declare AllowAddCleanup				bool local TRUE
-	/if (!${Defined[LastMercAssistID]}) /declare LastMercAssistID			int outer 0
-	/if (${Defined[callRoutine]}) {
+	/if (${AllowCombatBuff} == NULL) /varset AllowCombatBuff TRUE
+	/if (${AllowDebuff]} == NULL) /varset AllowDebuff TRUE
+	/if (${AllowAddCleanup]} == NULL) /varset AllowAddCleanup TRUE
+	/if (!${Defined[LastMercAssistID]}) /declare LastMercAssistID		int outer 0
+	/if (${callRoutine.NotEqual[NULL]}) {
 		/varset inCombatBuffRoutine ${callRoutine}
 	} else {
 		/varset inCombatBuffRoutine NULL
@@ -1098,7 +1101,8 @@ Sub CommonRoutines(bool pullCheck)
 	
 	/if (${Me.State.Equal[HOVER]}) /call Event_died
 	
-	/if (!${Defined[pullCheck]}) /declare pullCheck bool local TRUE
+	| /if (!${Defined[pullCheck]}) /declare pullCheck bool local TRUE
+	/if (${pullCheck} == NULL) /varset pullCheck TRUE
 	/if (${followMode}) /call SetHome
 	/call campCheck
 	| /call TradeCheck
@@ -1185,7 +1189,7 @@ Sub CommonRoutines(bool pullCheck)
 /return
 
 Sub AddIgnoreMob(string addName)
-	/if (${addName.Equal[null]}) /return
+	/if (${addName.Equal[NULL]}) /return
 	
 	/varcalc ignoreMobsCount ${ignoreMobsCount}+1
 	/varset ignoreMobs[${ignoreMobsCount}] ${addName}
@@ -1212,7 +1216,7 @@ Sub RemoveIgnoreMob(string removeName)
 /return
 
 Sub AddSafePC(string addName)
-	/if (${addName.Equal[null]}) /return
+	/if (${addName.Equal[NULL]}) /return
 	
 	/varcalc safePCCount ${safePCCount}+1
 	/varset safePC[${safePCCount}] ${addName}
@@ -1239,7 +1243,7 @@ Sub RemoveSafePC(string removeName)
 /return
 
 Sub AfterCombatRoutines(bool lootReturn)
-	/if (!${Defined[lootReturn]}) /declare lootReturn			bool local TRUE
+	/if (${lootReturn} == NULL) /varset lootReturn TRUE
 	/declare acArray			int local
 	
 	/if (${Me.Combat}) /attack off
@@ -1311,12 +1315,12 @@ Sub AlertsCheck(int mobID)
 	/declare aZero	int local 
 	
 	/if (!${mobAlertsValue}) /return
-	/if (!${Defined[mobID]}) {
+	/if (${mobID} == NULL) {
 		/if (${Target.ID}) {
-			/declare mobID	int local ${Target.ID}
+			/varset mobID ${Target.ID}
 		} else {
 			/if (${lTargCount}<1) /return
-			/declare mobID int local 0
+			/varset mobID 0
 		}
 	}
 
@@ -1374,9 +1378,9 @@ Sub AlertsCheck(int mobID)
 /return
 
 Sub CastBuff(int buffTargID, int buffNum, string buffType, string singGroup, bool silentMode, string castCallRoutine)
-	/if (!${Defined[singGroup]}) /declare singGroup			string local Single
-	/if (!${Defined[silentMode]}) /declare silentMode		bool local FALSE
-	/if (!${Defined[castCallRoutine]}) /declare castCallRoutine	string local CheckForAggro
+	/if (${singGroup.Equal[NULL]}) /varset singGroup Single
+	/if (${silentMode} == NULL) /varset silentMode FALSE
+	/if (${castCallRoutine.Equal[NULL]}) /varset castCallRoutine CheckForAggro
 	/if (!${castCallRoutine.Length} || ${castCallRoutine.Equal[NULL]}) /varset castCallRoutine CheckForAggro
 	
 	/declare buffString					string local groupBuff${singGroup}
@@ -1523,7 +1527,7 @@ Sub CastBuff(int buffTargID, int buffNum, string buffType, string singGroup, boo
 Sub FindPotionBelt(string PotionName)
 	/declare pbArray						int local 0
 
-	/if (!${Defined[PotionName]}) /return FALSE
+	/if (${PotionName.Equal[NULL]}) /return FALSE
 	/for pbArray 0 to 4
 		/if (${Window[PotionBeltWnd].Child[PW_PotionSlot${pbArray}_Button].Tooltip.Equal[${PotionName}]} && ${Window[PotionBeltWnd].Child[PW_PotionSlot${pbArray}_Label].Text}>0) {
 			/return TRUE
@@ -1552,8 +1556,8 @@ Sub CastPotionBelt(string PotionName, string CallRoutine) {
 	/declare pbArray						int local 0
 	/declare retValue						string local POTIONCAST_UNKNOWN
 	
-	/if (!${Defined[PotionName]}) /return POTIONCAST_NOTFOUND
-	/if (!${Defined[CallRoutine]}) /declare CallRoutine		string local NULL
+	/if (${PotionName.Equal[NULL]}) /return POTIONCAST_NOTFOUND
+	/if (${CallRoutine.Equal[NULL]}) /varset CallRoutine NULL
 	/if (!${Defined[PBCasting]}) /declare PBCasting				bool outer FALSE
 	/if (!${Defined[PBFailReason]}) /declare PBFailReason	string outer SUCCESS
 	/for pbArray 0 to 4
@@ -1614,9 +1618,8 @@ Sub Event_PBCastFail(string rLine)
 
 Sub buffCheck(bool useTimer, bool combatBuff, string onCallRoutine)
 	/if (!${castWhileInvis} && ${Me.Invis}) /return ABORT_INVIS
-	/if (!${Defined[useTimer]}) /declare useTimer bool local TRUE
-	/if (!${Defined[combatBuff]}) /declare combatBuff bool local FALSE
-	/if (!${Defined[onCallRoutine]}) /declare onCallRoutine string local NULL
+	/if (${useTimer} == NULL) /varset useTimer TRUE
+	/if (${combatBuff} == NULL) /varset combatBuff FALSE
 	/if (${useTimer} && ${minBuffCheckTimer}) /return ABORT_TIMER
 	/if (${selfBuffCount} == 0 && (!${Me.Pet.ID} || ${petBuffCount} == 0) && (${groupBuffCount} == 0 || !${Group.Members}) && (!${watchCount} || !${groupBuffCount}) && !${autoBuffCount}) /return ABORT_NOBUFFS
 
@@ -1636,7 +1639,7 @@ Sub buffCheck(bool useTimer, bool combatBuff, string onCallRoutine)
 /return
 
 Sub buffCheckNeeded(string checkBuffName, string checkBuffSpell, string targVariable, float gbMod)
-	/if (!${Defined[gbMod]}) /declare gbMod int local 0
+	/if (${gbMod} == NULL) /varset gbMod 0
 	/if (${checkBuffName.Equal[NULL]} && ${checkBuffSpell.Equal[NULL]}) /return FALSE
 	/if (${checkBuffName.Equal[NULL]} && ${checkBuffSpell.NotEqual[NULL]}) /varset checkBuffName ${checkBuffSpell}
 	/if (!${${targVariable}[${checkBuffName}].ID} || ${${targVariable}[${checkBuffName}].Duration.TotalSeconds} < ${Math.Calc[${Spell[${checkBuffSpell}].Duration.TotalSeconds}/10+${gbMod}]}) {
@@ -1646,10 +1649,9 @@ Sub buffCheckNeeded(string checkBuffName, string checkBuffSpell, string targVari
 /return FALSE
 
 Sub buffCheckRoutine(string checkTypes, bool combatBuff, string onCallRoutine)
-	/if (!${Defined[combatBuff]}) /declare combatBuff bool local FALSE
-	/if (!${Defined[onCallRoutine]}) /declare onCallRoutine string local NULL
-	/if (!${Defined[checkTypes]}) /declare checkTypes string local ALL
-	
+	/if (${combatBuff} == NULL) /varset combatBuff FALSE
+	/if (${checkTypes.Equal[NULL]}) /varset checkTypes ALL
+
 	/call EchoLog "Checking buffs (${checkTypes})- In Combat: ${combatBuff}" TRUE
 
 	/declare bArray							int local 0
@@ -1698,7 +1700,7 @@ Sub buffCheckRoutine(string checkTypes, bool combatBuff, string onCallRoutine)
 				/if (${autoBuff[${nArray}].NotEqual[NULL]} && ${autoBuffEnabled[${nArray}]} && ${autoBuffAuto[${nArray}]} && ${autoBuffCombat[${nArray}]}==${combatBuff}) {
 					/if (${Spell[${autoBuff[${nArray}]}].Stacks} || ${Spell[${autoBuffText[${nArray}]}].Stacks}) {
 						/if (${autoBuffText[${nArray}].NotEqual[NULL]}) {
-							/if (${Me.Aura[1].Equal[${autoBuffText[${nArray}]}]} || ${Me.Aura[1].Equal[${autoBuff[${nArray}]}]} || ${Me.Aura[2].Equal[${autoBuffText[${nArray}]}]} || ${Me.Aura[2].Equal[${autoBuff[${nArray}]}]}) {
+							/if (${Me.Aura[1].Name.Equal[${autoBuffText[${nArray}]}]} || ${Me.Aura[1].Name.Equal[${autoBuff[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${autoBuffText[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${autoBuff[${nArray}]}]}) {
 								| Work around for MQ2 aura bug
 							} else {
 								/if ((!${Me.Buff[${autoBuffText[${nArray}]}].ID} || ${Me.Buff[${autoBuffText[${nArray}]}].Duration} <= ${Math.Calc[${Spell[${autoBuff[${nArray}]}].Duration.TotalSeconds}/10]}) && !${Me.Song[${autoBuffText[${nArray}]}].ID}) {
@@ -1710,7 +1712,7 @@ Sub buffCheckRoutine(string checkTypes, bool combatBuff, string onCallRoutine)
 								}
 							}
 						} else {
-							/if (${Me.Aura[1].Equal[${autoBuff[${nArray}]}]} || ${Me.Aura[2].Equal[${autoBuff[${nArray}]}]}) {
+							/if (${Me.Aura[1].Name.Equal[${autoBuff[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${autoBuff[${nArray}]}]}) {
 								| Work around for MQ2 aura bug
 							} else {
 								/if ((!${Me.Buff[${autoBuff[${nArray}]}].ID} ||  ${Me.Buff[${autoBuff[${nArray}]}].Duration} <= ${Math.Calc[${Spell[${autoBuff[${nArray}]}].Duration.TotalSeconds}/10]})) {
@@ -1988,13 +1990,13 @@ Sub buffCheckRoutine(string checkTypes, bool combatBuff, string onCallRoutine)
 				/call buffCheckStacking buff ${nArray} Me.Buff
 				/if (${Macro.Return.Equal[TRUE]}) {
 					/if (${buffText[${nArray}].NotEqual[NULL]}) {
-						/if (${Me.Aura[1].Equal[${buffText[${nArray}]}]} || ${Me.Aura[1].Equal[${buffName[${nArray}]}]} || ${Me.Aura[2].Equal[${buffText[${nArray}]}]} || ${Me.Aura[2].Equal[${buffName[${nArray}]}]}) {
+						/if (${Me.Aura[1].Name.Equal[${buffText[${nArray}]}]} || ${Me.Aura[1].Name.Equal[${buffName[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${buffText[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${buffName[${nArray}]}]}) {
 							| Work around for MQ2 aura bug
 						} else {
 							/if ((!${Me.Buff[${buffText[${nArray}]}].ID} || ${Me.Buff[${buffText[${nArray}]}].Duration} <= ${Math.Calc[${Spell[${buffName[${nArray}]}].Duration.TotalSeconds}/10]}) && !${Me.Song[${buffText[${nArray}]}].ID}) /call CastBuff ${Me.ID} ${nArray} SELF
 						}
 					} else {
-						/if (${Me.Aura[1].Equal[${buffName[${nArray}]}]} || ${Me.Aura[2].Equal[${buffName[${nArray}]}]}) {
+						/if (${Me.Aura[1].Name.Equal[${buffName[${nArray}]}]} || ${Me.Aura[2].Name.Equal[${buffName[${nArray}]}]}) {
 							| Work around for MQ2 aura bug
 						} else {
 							/if ((!${Me.Buff[${buffName[${nArray}]}].ID} ||  ${Me.Buff[${buffName[${nArray}]}].Duration} <= ${Math.Calc[${Spell[${buffName[${nArray}]}].Duration.TotalSeconds}/10]})) /call CastBuff ${Me.ID} ${nArray} SELF
@@ -2080,7 +2082,7 @@ Sub buffCheckStacking(string buffType, int buffID, string buffTargetVar, string 
 	/declare thisSpellName	string local
 	/declare currBaseSpell	string local NULL
 	
-	/if (!${Defined[buffSubType]}) /declare buffSubType string local 
+	/if (${buffSubType.Equal[NULL]}) /varset buffSubType 
 	/if (${buffType.Find[group]}) /varset textVar Display
 	/if (${buffType.Equal[buff]}) /varset nameVar Name
 	
@@ -2180,7 +2182,7 @@ Sub campCheck(bool pauseCheck)
 	/declare pcID			int local
 	/declare pcNum		int local 0
 	/declare campSafe	bool local
-	/if (!${Defined[pauseCheck]}) /declare pauseCheck bool local FALSE
+	/if (${pauseCheck}) /varset pauseCheck FALSE
 	/if (!${Defined[unsafePCLastCheckCombat]}) /declare unsafePCLastCheckCombat bool outer ${inCombat}
 	
 	/if (${Spawn[GM].ID}) {
@@ -2267,7 +2269,7 @@ Sub CastSpell(string spellType, bool combatMem, bool faceTarg, bool AllowDiscs)
 	}
 	/if (!${castWhileInvis} && ${Me.Invis}) /return ABORT_INVIS
 	/if (${priorityCombatSpellsTimer}) /return ABORT_TIMER
-	/if (!${Defined[faceTarg]}) /declare faceTarg				bool local ${faceWhenCasting}
+	/if (${faceTarg} == NULL) /varset faceTarg ${faceWhenCasting}
 	/if (!${doCombatSpells}) /return ABORT_DISABLED
 	/if (${Me.Moving}) /return ABORT_MOVING
 	/declare cCondition		bool local
@@ -2281,9 +2283,9 @@ Sub CastSpell(string spellType, bool combatMem, bool faceTarg, bool AllowDiscs)
 	/declare restartTwist	bool local FALSE
 	/declare iLoop				int local 0
 	
-	/if (!${Defined[AllowDiscs]}) /declare AllowDiscs bool local TRUE
-	/if (!${Defined[spellType]} || ${spellType.Equal[NULL]}) {
-		/if (!${Defined[spellType]}) /declare spellType string local
+	/if (${AllowDiscs} == NULL) /varset AllowDiscs TRUE
+	/if (${spellType.Equal[NULL]}) {
+		/varset spellType 
 		/if (${spellTypeValue}) {
 			/varset sTypeNum 1
 			/varset spellType ${spellTypes[${sTypeNum}]}
@@ -2291,7 +2293,7 @@ Sub CastSpell(string spellType, bool combatMem, bool faceTarg, bool AllowDiscs)
 			/varset spellType ALL
 		}
 	}
-	/if (!${Defined[combatMem]}) /declare combatMem bool local TRUE
+	/if (${combatMem} == NULL) /varset combatMem TRUE
 	/if (!${csCount}) /return ABORT_NOSPELLS
 	/if (${globalCooldown}) /return ABORT_COOLDOWN
 	/if (${giftSpell}) {
@@ -2595,7 +2597,7 @@ Sub CastSpell(string spellType, bool combatMem, bool faceTarg, bool AllowDiscs)
 /return ${retValue}
 
 Sub CheckFriendList(int friendID)
-	/if (!${Defined[friendID]}) /return FALSE
+	/if (${friendID} == NULL) /return FALSE
 	/call CreateFriendList
 	/if (${friendList.Find[|${friendID}|]}) /return TRUE
 /return FALSE
@@ -2611,10 +2613,10 @@ Sub IsDetectedAdd(int checkID)
 /return FALSE
 
 Sub CheckForXTargetAdds(int cDist, int checkID, bool checkAll, bool silentRun)
-	/if (!${Defined[cDist]}) /declare cDist int local ${campRadius}
-	/if (!${Defined[checkAll]}) /declare checkAll bool local TRUE
-	/if (!${Defined[silentRun]}) /declare silentRun bool local FALSE
-	/if (!${Defined[checkID]}) /declare checkID int local 0
+	/if (${cDist} == NULL) /varset cDist ${campRadius}
+	/if (${checkAll} == NULL) /varset checkAll TRUE
+	/if (${silentRun} == NULL) /varset silentRun FALSE
+	/if (${checkID} == NULL) /varset checkID 0
 	
 	/declare xTargLoop			int local 0
 	/declare freeXTarget		int local 0
@@ -2622,6 +2624,7 @@ Sub CheckForXTargetAdds(int cDist, int checkID, bool checkAll, bool silentRun)
 	/declare checkY					float local ${If[!${checkID},${homeY},${Spawn[${checkID}].Y}]}
 	/declare checkX					float local ${If[!${checkID},${homeX},${Spawn[${checkID}].X}]}
 	
+	HIGHERDEBUG "Checking XTarget for adds" TRUE 5
 	/for xTargLoop 1 to ${maxXTargets}
 		/if (${Me.XTarget[${xTargLoop}].${xTargType}.Equal[Auto Hater]} && !${Me.XTarget[${xTargLoop}].ID}) /varcalc freeXTarget ${freeXTarget} + 1
 		/if (${Me.XTarget[${xTargLoop}].ID}) {
@@ -2644,13 +2647,13 @@ Sub CheckForXTargetAdds(int cDist, int checkID, bool checkAll, bool silentRun)
 	/next xTargLoop
 /return ${freeXTarget}
 
-Sub CheckForAdds(int cDist, int checkID,  bool useChoose, bool checkAll, bool silentRun)
+Sub CheckForAdds(int cDist, int checkID, bool useChoose, bool checkAll, bool silentRun)
 	/if (${priorityAddCheckTimer}) /return ABORT_TIMER
-	/if (!${Defined[cDist]}) /declare cDist int local ${campRadius}
-	/if (!${Defined[checkID]}) /declare checkID int local 0
-	/if (!${Defined[useChoose]}) /declare useChoose bool local FALSE
-	/if (!${Defined[checkAll]}) /declare checkAll bool local TRUE
-	/if (!${Defined[silentRun]}) /declare silentRun bool local FALSE
+	/if (${cDist} == NULL) /varset cDist ${campRadius}
+	/if (${checkID} == NULL) /varset checkID 0
+	/if (${useChoose} == NULL) /varset useChoose FALSE
+	/if (${checkAll} == NULL) /varset checkAll TRUE
+	/if (${silentRun} == NULL) /varset silentRun FALSE
 
 	/if (${checkID} && !${Spawn[${checkID}].ID}) /varset checkID 0
 	/if (!${checkID} && (${followMode} || (${Defined[soloMode]} && ${soloMode}))) /varset checkID ${Me.ID}
@@ -2748,6 +2751,7 @@ Sub CheckForAdds(int cDist, int checkID,  bool useChoose, bool checkAll, bool si
 			}		
 	}
 	:endDetection
+	HIGHERDEBUG "CheckForAdds completed.  newAddID: ${newAddID" TRUE 5
 	/if (${useChoose}) {
 		/call ChooseTarget ${newAddID}
 	} else {
@@ -2767,7 +2771,7 @@ Sub CheckForAggro(int mobCheck)
 	/declare mobHeading 		float local
 	/declare mobToMeHeading float local
 	/declare mToTID					int local 0
-	/if (!${Defined[mobCheck]}) /declare mobCheck				int local 0
+	/if (${mobCheck} == NULL) /varset mobCheck 0
 
 	/if (!${checkForAdds}) /varset mobCheck ${targID}
 	
@@ -3389,6 +3393,7 @@ Sub CommonINILoad
 	/declare priorityAddCheck					string outer 5s
 	/declare priorityAssist						string outer 3s
 	/declare priorityUnsafePC					string outer 30s**|
+	/declare priorityDebuffs					string outer 20s
 	/declare priorityDebuffsTimer				timer outer 0s
 	/declare priorityAutoBuffsTimer			timer outer 0s
 	/declare prioritySelfBuffsTimer			timer outer 0s
@@ -3577,8 +3582,8 @@ Sub ChooseTarget(int forceTarg, int baseAround)
 	/varset newAdd FALSE
 	/varset newTarg FALSE
 
-	/if (!${Defined[forceTarg]}) /declare forceTarg int local 0
-	/if (!${Defined[baseAround]}) /declare baseAround int local ${Me.ID}
+	/if (${forceTarg} == NULL) /varset forceTarg 0
+	/if (${baseAround} == NULL) /varset baseAround ${Me.ID}
 	
 	/if ((!${forceTarg} || !${useForceTarg}) && (!${groupMode} || !${Spawn[${mainAssist}].ID} || ${Spawn[${mainAssist}].Type.Equal[Corpse]} || (${Spawn[${mainAssist}].Linkdead} && ${Spawn[${mainAssist}].Type.NotEqual[mercenary]}) || ${mainAssist.Equal[${Me.CleanName}]} || ${mainAssist.Equal[NULL]})) {
 		/for tLoop 1 to ${targCount}
@@ -3652,8 +3657,8 @@ Sub ChooseTarget(int forceTarg, int baseAround)
 /return
 
 Sub ClearCursor(string clearType,string maxAttemptTime)
-	/if (!${Defined[clearType]}) /declare clearType string local AUTOINVENTORY
-	/if (!${Defined[maxAttemptTime]}) /declare maxAttemptTime string local 15s
+	/if (${clearType.Equal[NULL]}) /varset clearType AUTOINVENTORY
+	/if (${maxAttemptTime.Equal[NULL]}) /varset maxAttemptTime 15s
 	/if (!${Select[${clearType},AUTOINV,AUTO,AUTOINVENTORY,DESTROY,DEST]}) /varset clearType AUTOINVENTORY
 	/declare clearCursorTimer		timer local ${maxAttemptTime}
 
@@ -3710,7 +3715,7 @@ Sub CreateFriendList
 /return
 
 Sub CreateIgnoreAlert(int aListNum)
-	/if (!${Defined[aListNum]}) /declare aListNum int local ${alertList}
+	/if (${aListNum} == NULL) /varset aListNum ${alertList}
 	/varset alertList ${aListNum}
 	
 	/squelch /alert clear ${aListNum}
@@ -3729,7 +3734,7 @@ Sub CreateIgnoreAlert(int aListNum)
 /return
 
 Sub CreateSafeAlert(int aListNum)
-	/if (!${Defined[aListNum]}) /declare aListNum int local ${safeAlertList}
+	/if (${aListNum} == NULL) /varset aListNum ${safeAlertList}
 	/varset safeAlertList ${aListNum}
 	
 	/squelch /alert clear ${aListNum}
@@ -3880,7 +3885,7 @@ Sub DebuffRoutine(int mobID)
 	/if (${priorityDebuffsTimer}) /return ABORT_TIMER
 	/if (${debuffCheckTimer}) /return ABORT_TIMER
 	/if (${Me.Moving}) /return ABORT_MOVING
-	/if (!${Defined[mobID]}) /declare mobID		int local 0
+	/if (${mobID} == NULL) /varset mobID 0
 	/declare currID				int local
 	/declare dArray				int local
 	
@@ -3925,9 +3930,9 @@ Sub DoNotAttackCheck
 Sub EchoLog(string eMsg, bool logOnly, int msgLevel)
 	/declare sMsg			string local
 
-	/if (!${Defined[eMsg]})	/return
-	/if (!${Defined[logOnly]}) /declare logOnly	bool local FALSE
-	/if (!${Defined[msgLevel]}) /declare msgLevel int local 0
+	/if (${eMsg.Equal[NULL]})	/return
+	/if (${logOnly} == NULL) /varset logOnly FALSE
+	/if (${msgLevel} == NULL) /varset msgLevel 0
 
 	/if (${msgLevel} <= ${debugLvl}) {
 		/call StripText "${eMsg}"
@@ -3941,9 +3946,9 @@ Sub EchoLog(string eMsg, bool logOnly, int msgLevel)
 /return
 
 Sub Evac(bool campOut, bool campOutOnly, bool silentEvac)
-	/if (!${Defined[campOut]}) /declare campOut bool local TRUE
-	/if (!${Defined[campOutOnly]}) /declare campOutOnly bool local FALSE
-	/if (!${Defined[silentEvac]}) /declare silentEvac bool local FALSE
+	/if (${campOut} == NULL) /varset campOut TRUE
+	/if (${campOutOnly} == NULL) /varset campOutOnly FALSE
+	/if (${silentEvac} == NULL) /varset silentEvac FALSE
 	
 	/if (!${campOutOnly}) {
 		/call EchoLog "Attempting to gate out"
@@ -3973,19 +3978,18 @@ Sub Evac(bool campOut, bool campOutOnly, bool silentEvac)
 /return
 
 Sub GetINISetting(string ININame,string INISection,string INIKey,string VariableName,string defaultValue,string createSettingStr,string variableType)
-	/if (!${Defined[ININame]}) /return INVALIDINI
-	/if (!${Defined[INISection]}) /return INVALIDSECTION
-	/if (!${Defined[INIKey]}) /return INVALIDKEY
-	/if (!${Defined[VariableName]}) /return INVALIDVARIABLE	
-	/if (${Defined[createSettingStr]} && ${createSettingStr.NotEqual[TRUE]} && ${createSettingStr.NotEqual[FALSE]} && !${Defined[variableType]}) {
-		/declare variableType		string local ${createSettingStr}
+	/if (${ININame.Equal[NULL]}) /return INVALIDINI
+	/if (${INISection.Equal[NULL]}) /return INVALIDSECTION
+	/if (${INIKey.Equal[NULL]}) /return INVALIDKEY
+	/if (${VariableName.Equal[NULL]}) /return INVALIDVARIABLE	
+	/if (${createSettingStr.NotEqual[NULL]} && ${createSettingStr.NotEqual[TRUE]} && ${createSettingStr.NotEqual[FALSE]} && ${variableType.Equal[NULL]}) {
+		| /declare variableType		string local ${createSettingStr}
+		/varset variableType ${createSettingStr}
 		/declare createSetting	bool local TRUE
-	} else /if (${Defined[createSettingStr]}) {
+	} else /if (${createSettingStr.NotEqual[NULL]}) {
 		/declare createSetting	bool local ${createSettingStr}
 	}
 	/if (!${Defined[createSetting]}) /declare createSetting 	bool local TRUE
-	/if (!${Defined[defaultValue]}) /declare defaultValue 		string local NULL
-	/if (!${Defined[variableType]}) /declare variableType			string local NULL
 	/declare iniValue						string local NULL
 	
 	/varset iniValue ${Ini[${ININame},${INISection},${INIKey},DOES_NOT_EXIST]}
@@ -3993,19 +3997,26 @@ Sub GetINISetting(string ININame,string INISection,string INIKey,string Variable
 		/if (${createSetting}) /ini "${ININame}" "${INISection}" "${INIKey}" "${defaultValue}"
 		/varset iniValue ${defaultValue}
 	}
-	/if (!${Defined[${VariableName}]} && ${variableType.NotEqual[NULL]}) /declare ${VariableName} ${variableType} outer
-	/if (${VariableName.NotEqual[NULL]}) /varset ${VariableName} ${iniValue}
+
+	/declare variableDefName string local ${VariableName}
+	| /declare variableIndex int local 0
+	/if (${VariableName.Find[[]}) {
+		/varset variableDefName ${VariableName.Left[${Math.Calc[${VariableName.Find[[]} - 1]}]}
+		| /varset variableIndex ${VariableName.Mid[${Math.Calc[${VariableName.Find[[]} + 1]},${Math.Calc[${VariableName.Find[]]} - ${VariableName.Find[[]} + 1]}]}
+	}
+	/if (!${Defined[${variableDefName}]} && !${VariableName.Find[[]} && ${variableType.NotEqual[NULL]}) /declare ${VariableName} ${variableType} outer
+	/if (${Defined[${variableDefName}]} && ${VariableName.NotEqual[NULL]}) /varset ${VariableName} ${iniValue}
 /return COMPLETED
 
 | Needs to be worked on if you want to use!!  Is ok for simple applications
 Sub GetINIArray(string ININame,string INISection,string INIKeyPrefix,string ArrayName,string ArrayType,string defaultValue,int createNum)
-	/if (!${Defined[ININame]}) /return INVALIDINI
-	/if (!${Defined[INISection]}) /return INVALIDSECTION
-	/if (!${Defined[INIKeyPrefix]}) /return INVALIDKEYPREFIX
-  /if (!${Defined[ArrayName]}) /return INVALIDARRAY
-  /if (!${Defined[ArrayType]}) /declare ArrayType						string local string
-	/if (!${Defined[createNum]}) /declare createNum 					int local 1
-	/if (!${Defined[defaultValue]}) /declare defaultValue 		string local NULL
+	/if (${ININame.Equal[NULL]}) /return INVALIDINI
+	/if (${INISection.Equal[NULL]}) /return INVALIDSECTION
+	/if (${INIKeyPrefix.Equal[NULL]}) /return INVALIDKEYPREFIX
+  /if (${ArrayName.Equal[NULL]}) /return INVALIDARRAY
+  /if (${ArrayType.Equal[NULL]}) /varset ArrayType string
+	/if (${createNum} == NULL) /varset createNum 1
+	/if (${defaultValue.Equal[NULL]}) /varset defaultValue NULL
 	/declare iniValue						string local NULL
 	/declare iniArrayCount			int local 0
 	/declare arraySize					int local 0
@@ -4033,10 +4044,9 @@ Sub GetINIArray(string ININame,string INISection,string INIKeyPrefix,string Arra
 /return COMPLETED
 
 Sub GetINIArrayCount(string ININame,string INISection,string INIKeyPrefix,string invalidValue)
-	/if (!${Defined[ININame]}) /return 0
-	/if (!${Defined[INISection]}) /return 0
-	/if (!${Defined[INIKeyPrefix]}) /return 0
-	/if (!${Defined[invalidValue]}) /declare invalidValue				string local NULL
+	/if (${ININame.Equal[NULL]}) /return 0
+	/if (${INISection.Equal[NULL]}) /return 0
+	/if (${INIKeyPrefix.Equal[NULL]}) /return 0
 	/declare iniCount					int local 0
 	/declare nullCount				int local 0
 	
@@ -4143,7 +4153,7 @@ Sub GetMTTarget()
 /return ${mtTargetID}
 
 Sub CommonGetTarget(bool targNew)
-	/if (!${Defined[targNew]}) /declare targNew bool local TRUE
+	/if (${targNew} == NULL) /varset targNew TRUE
 	/declare newTargID						int local 0
 	/declare targLoop							int local 0
 
@@ -4181,8 +4191,8 @@ Sub CommonGetTarget(bool targNew)
 /return ${newTargID}
 
 Sub GlobalCommands(string comFrom, string comText, bool fromEQBC)
-	/if (!${Defined[comFrom]} || !${Defined[comText]}) /return ABORT_PARAMS
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC				bool local FALSE
+	/if (${comFrom.Equal[NULL]} || ${comText.Equal[NULL]}) /return ABORT_PARAMS
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare retValue									string local COMPLETED_NOTFOUND
 	/declare paramCount								int local
 	/varcalc paramCount ${comText.Count[ ]} + 1
@@ -4857,7 +4867,7 @@ Sub GlobalCommands(string comFrom, string comText, bool fromEQBC)
 Sub ItemSwapCheck(string itemName)
 	/declare needToSwap		bool local FALSE
 	/declare slotsReq		int local
-	/if (!${Defined[itemName]} && !${itemSwapped}) {
+	/if (${itemName.Equal[NULL]} && !${itemSwapped}) {
 		/call EchoLog "No item specified to check for, aborting swap check." TRUE
 		/return
 	}
@@ -4925,7 +4935,7 @@ Sub pauseActions
 Sub SafePC(string pcName)
 	/declare isSafe 	bool local FALSE
 	/declare inum			int local
-	/if (!${Defined[pcName]}) {
+	/if (${pcName.Equal[NULL]}) {
 		/call EchoLog "Pc name not specified for safe pc check, aborting and returning as unsafe" TRUE
 		/return FALSE
 	}
@@ -4972,7 +4982,7 @@ Sub StripText(string cString)
 	/declare wString		string local
 	/declare argString	string local
 	
-	/if (!${Defined[cString]}) /return
+	/if (${cString.Equal[NULL]}) /return
 	/if (!${cString.Find[\]}) /return ${cString}
 	/varset wString ${cString}
 	
@@ -4987,9 +4997,8 @@ Sub StripText(string cString)
 /return ${cString}
 
 Sub SummonItem(string spellName, string spellSlot, string targetName, string itemName, bool putInInv, bool unfold)
-	/if (!${Defined[itemName]}) /declare itemName string local NULL
-	/if (!${Defined[putInInv]}) /declare putInInv bool local TRUE
-	/if (!${Defined[unfold]}) /declare unfold bool local TRUE
+	/if (${putInInv} == NULL) /varset putInInv TRUE
+	/if (${unfold} == NULL) /varset unfold TRUE
 	/declare pLoop		int local
 	/declare pFound		bool local FALSE
 	/declare emptyPrimary		int local 0
@@ -5170,14 +5179,14 @@ Sub SummonedItemsCheck
 /return
 
 Sub Timer(string timerPrefix, int timerID, string setTo, bool delTimer)
-	/if (${Defined[delTimer]} && ${delTimer}) {
+	/if (${delTimer}) {
 		/if (${timerID} >= 0) {
 			/if (!${Defined[${timerPrefix}Timer${timerID}]}) /deletevar ${timerPrefix}Timer${timerID}
 		} else {
 			/if (!${Defined[${timerPrefix}Timer]}) /deletevar ${timerPrefix}Timer
 		}
 	} else {
-		/if (${Defined[setTo]}) {
+		/if (${setTo.NotEqual[NULL]}) {
 			/if (${timerID} >= 0) {
 				/if (!${Defined[${timerPrefix}Timer${timerID}]}) /declare ${timerPrefix}Timer${timerID} timer outer 0s
 				/varset ${timerPrefix}Timer${timerID} ${setTo}
@@ -5186,9 +5195,9 @@ Sub Timer(string timerPrefix, int timerID, string setTo, bool delTimer)
 				/varset ${timerPrefix}Timer ${setTo}			
 			}
 		} else {
-			/if (${Defined[timerID]} && ${timerID} >= 0 && (!${Defined[${timerPrefix}Timer${timerID}]} || !${${timerPrefix}Timer${timerID}})) {
+			/if (${timerID} != NULL && ${timerID} >= 0 && (!${Defined[${timerPrefix}Timer${timerID}]} || !${${timerPrefix}Timer${timerID}})) {
 				/return FALSE
-			} else /if ((!${Defined[timerID]} || ${timerID} < 0) && (!${Defined[${timerPrefix}Timer]} || !${${timerPrefix}Timer})) {
+			} else /if ((${timerID} == NULL || ${timerID} < 0) && (!${Defined[${timerPrefix}Timer]} || !${${timerPrefix}Timer})) {
 				/return FALSE
 			} else {
 				/return TRUE
@@ -5223,7 +5232,7 @@ Sub TrackKillCount(string killName,bool allMatches)
 	/declare tkLoop			int local 0
 	/declare knFound		bool local FALSE
 	/declare tkCount		int local 0
-	/if (!${Defined[allMatches]}) /declare allMatches bool FALSE
+	/if (${allMatches} == NULL) /varset allMatches FALSE
 	
 	/for tkLoop 1 to 200
 		/if ((!${allMatches} && ${killTrack[${tkLoop},1].Equal[${killName}]}) || (${allMatches} && ${killTrack[${tkLoop},1].Find[${killName}]})) {
@@ -5236,7 +5245,7 @@ Sub TrackKillCount(string killName,bool allMatches)
 Sub TrackKillReset(string killName,bool allMatches)
 	/declare tkLoop			int local 0
 	/declare knFound		bool local FALSE
-	/if (!${Defined[allMatches]}) /declare allMatches bool FALSE
+	/if (${allMatches} == NULL) /varset allMatches FALSE
 	
 	/for tkLoop 1 to 200
 		/if ((!${allMatches} && ${killTrack[${tkLoop},1].Equal[${killName}]}) || (${allMatches} && ${killTrack[${tkLoop},1].Find[${killName}]})) {
@@ -5336,7 +5345,7 @@ Sub WaitForRez(string maxWaitTime)
 		/varset deathZ ${homeZ}
 	}
 	/declare waitTimer			bool local FALSE
-	/if (${Defined[maxWaitTime]} && !${Select[${maxWaitTime},0,0s,0m,00,0h]}) {
+	/if (${maxWaitTime.NotEqual[NULL]} && !${Select[${maxWaitTime},0,0s,0m,00,0h]}) {
 		/declare maxWaitTimer timer local ${maxWaitTime}
 		/varset waitTimer TRUE
 	}
@@ -5507,7 +5516,7 @@ Sub Event_rTell(rLine,string rFrom,string rMsg, string rType)
 	/declare hMsg		string local
 	/declare rFromID	int local 0
 	/declare rFromEQBC	bool local FALSE
-	/if (!${Defined[rType]}) /declare rType				string local TELL
+	/if (${rType.Equal[NULL]}) /varset rType TELL
 	
 	/if (${rFrom.Equal[${Me.Pet.CleanName}]}) /return
 	/if (${rType.Equal[TELL]} && !${tellCommands}) /return
@@ -5653,8 +5662,8 @@ Sub Event_mercStanceChange(line,string newStance)
 /return
 
 Sub MissionCommandHandler(string comFrom, string comText, bool fromEQBC)
-	/if (!${Defined[comFrom]} || !${Defined[comText]}) /return ABORT_PARAMS
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC				bool local FALSE
+	/if (${comFrom.Equal[NULL]} || ${comText.Equal[NULL]}) /return ABORT_PARAMS
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare retValue									string local COMPLETED_NOTFOUND
 	/declare paramCount								int local
 	/varcalc paramCount ${comText.Count[ ]} + 1
@@ -5720,7 +5729,7 @@ Sub MissionCommandSend(string sendTo,string sendText,bool missionCommTagged)
 		/varset commandMethod /tell
 		/varset postSendDelay 5
 	}
-	/if (!${Defined[missionCommTagged]}) /declare missionCommTagged bool local TRUE
+	/if (${missionCommTagged} == NULL) /varset missionCommTagged TRUE
 	/if (${sendTo.Equal[LEADER]} && ${missionLeader.Equal[GROUP]}) {
 		/varset sendTo ${Group.Leader.Name}
 	} else /if (${sendTo.Equal[LEADER]}) {
@@ -5759,7 +5768,7 @@ Sub MissionFollowerStatus(string followerName,string statusString,bool setStatus
 	/declare mfLoop			int local 1
 	/declare mfWhile		bool local TRUE
 	/declare mfRetValue	string local TRUE
-	/if (!${Defined[setStatus]}) /declare setStatus bool local FALSE
+	/if (${setStatus} == NULL) /varset setStatus FALSE
 	
 	/if (!${setStatus}) {
 		/if (${followerName.Equal[ANY]}) /varset mfRetValue FALSE
@@ -5903,7 +5912,7 @@ Sub MissionLoadAction(int actionNumber,bool buildINI)
 	/declare actionMainTank	string local NULL
 	/declare actionPuller		string local NULL
 	/declare actionMainAssist string local NULL
-	/if (!${Defined[buildINI]}) /declare buildINI bool local FALSE
+	/if (${buildINI} == NULL) /varset buildINI FALSE
 	
 	/call EchoLog "Attempting to load mission action ${actionNumber} from INI ${missionINI}" TRUE
 	
@@ -6066,7 +6075,7 @@ Sub MissionLoadAction(int actionNumber,bool buildINI)
 /return TRUE
 
 Sub MissionModeEnd(string endReason)
-	/if (${Defined[endReason]}) /call EchoLog "${endReason}"
+	/if (${endReason.NotEqual[NULL]}) /call EchoLog "${endReason}"
 	/if (${missionAmLeader}) /call MissionCommandSend ALL "MissionMode OFF" FALSE
 	/varset missionMode FALSE
 	/varset missionStatus NULL	

--- a/devLoot.inc
+++ b/devLoot.inc
@@ -1,5 +1,5 @@
 | ======================================================================================================
-| 																		devLoot.inc v1.36
+| 																		devLoot.inc v1.37
 | 																	Written By - Devestator
 | 
 | Description:
@@ -10,6 +10,9 @@
 | USAGE:  This is primarily intended for use in macros.  /call Loot <corpseID>
 |   This will automatically loot the specified corpseID, or you can leave corpseID blank and it will
 |    loot all corpses within the INI set CorpseRadius.
+| 
+| v1.37 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.36 Update Notes
 |  -Added auto ignoring of lore items that the character already has
@@ -116,7 +119,7 @@ Sub BuildCorpseArray
 /return
 
 Sub BuildINI(string iniBuild)
-	/if (!${Defined[iniBuild]}) /declare iniBuild				string local ${lootINI}
+	/if (${iniBuild.Equal[NULL]}) /varset iniBuild ${lootINI}
 	
 	/ini ${iniBuild} Settings CorpseRadius ${corpseRadius}
 	/ini ${iniBuild} Settings LinkChannel ${linkChannel}
@@ -186,7 +189,7 @@ Sub Event_cannotLoot
 
 Sub Loot(int corpseID)
 	/if (!${Defined[devLootFirstRun]}) /call LootInit
-	/if (!${Defined[corpseID]}) /declare corpseID					int local 0
+	/if (${corpseID} == NULL) /varset corpseID 0
 	/if (!${Defined[clArray]}) /declare clArray						int outer 0
 	
 	/if (${Cursor.ID}) {
@@ -213,7 +216,6 @@ Sub Loot(int corpseID)
 
 Sub LootBank(string bankerName)
 	/if (!${Defined[devLootFirstRun]}) /call LootInit
-	/if (!${Defined[bankerName]}) /declare bankerName					string local NULL
 	/declare invItem						int local 0
 	/declare cItemAction				string local
 	/declare bankType						string local BIGB
@@ -434,7 +436,7 @@ Sub LootCorpse(int corpseID)
 /return LOOT_UNKNOWN
 
 Sub LootEcho(string echoMsg,bool logOnly)
-	/if (!${Defined[logOnly]}) /declare logOnly			bool local FALSE
+	/if (${logOnly} == NULL) /varset logOnly FALSE
 	/if (${Defined[devCommonVer]}) {
 		/call EchoLog "${echoMsg}" ${logOnly}
 	} else {
@@ -445,7 +447,7 @@ Sub LootEcho(string echoMsg,bool logOnly)
 
 Sub LootInit(bool silentLoad, string devLootIniName)
 	/declare devLootVersion			float outer 1.36
-	/if (!${Defined[devLootIniName]}) /declare devLootIniName					string local devLoot.ini
+	/if (${devLootIniName.Equal[NULL]}) /varset devLootIniName devLoot.ini
 	/declare lootINI						string outer ${devLootIniName}
 	/declare linkNoDrop					bool outer true
 	/declare linkLeave					bool outer true
@@ -494,9 +496,9 @@ Sub LootInit(bool silentLoad, string devLootIniName)
 /return
 
 Sub LootItem(int itemNum,bool destItem, string mouseKey)
-	/if (!${Defined[itemNum]}) /return
-	/if (!${Defined[mouseKey]}) /declare mouseKey			string local right
-	/if (!${Defined[destItem]}) /declare destItem			bool local false
+	/if (${itemNum} == NULL) /return
+	/if (${mouseKey.Equal[NULL]}) /varset mouseKey right
+	/if (${destItem} == NULL) /varset destItem false
 	/if (${destItem}) /varset mouseKey Left
 	/declare isNoDrop						bool local false
 
@@ -535,7 +537,6 @@ Sub LootItem(int itemNum,bool destItem, string mouseKey)
 
 Sub LootSell(string merchName)
 	/if (!${Defined[devLootFirstRun]}) /call LootInit
-	/if (!${Defined[merchName]}) /declare merchName					string local NULL
 	/declare invItem						int local 0
 	/declare cItemAction				string local
 	
@@ -624,7 +625,7 @@ Sub lootstrafePastObstacle
 
 Sub LootTracker(int corpseID,bool addTracker)
 	/if (!${Defined[corpseArray]}) /declare corpseArray[1000]							int outer
-	/if (!${Defined[addTracker]}) /declare addTracker											bool local false
+	/if (${addTracker} == NULL) /varset addTracker FALSE
 	/declare ltArray								int local
 	
 	/if (!${addTracker}) {
@@ -665,8 +666,8 @@ Sub LootTrackerClean
 /return
 
 Sub MoveToCorpse(int MoveToID, int StopDistance) 
-	/if (!${Defined[MoveToID]} || !${Spawn[${MoveToID}].ID} || ${Spawn[${MoveToID}].Type.NotEqual[Corpse]}) /return
-  /if (!(${Defined[StopDistance]})) /declare StopDistance int local 20
+	/if (${MoveToID} == NULL || !${Spawn[${MoveToID}].ID} || ${Spawn[${MoveToID}].Type.NotEqual[Corpse]}) /return
+  /if (${StopDistance} == NULL) /varset StopDistance 20
 
   /declare running						int local 0
   /declare distanceNow				float local 

--- a/devMovementPremium.inc
+++ b/devMovementPremium.inc
@@ -1,10 +1,13 @@
 | ========================================================================================================
-| 					 devMovementPremium.inc V1.73
+| 					 devMovementPremium.inc V1.74
 | 					Written By: Devestator
 | 
 | 
 | Description:
 |  Movement routines used in bots by Devestator
+| 
+| v1.74 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.73 Update Notes
 |  -Tweaked some position check values
@@ -79,10 +82,10 @@
 #event summoned "You have been summoned!"
 
 Sub MovementInit(bool initSilent,bool requireCommon)
-	/if (!${Defined[requireCommon]}) /declare requireCommon bool local TRUE
+	/if (${requireCommon} == NULL) /varset requireCommon TRUE
 	/declare moveRequireCommon			bool outer ${requireCommon}
 	
-	/declare reqDevCommon						float outer 2.48
+	/declare reqDevCommon						float outer 2.51
 	/if (${requireCommon} && (!${Defined[devCommonVer]} || ${devCommonVer} < ${reqDevCommon})) {
 		/echo Cannot load devMovement.inc due to missing incompatible version: devCommon version: ${devCommonVer}, Needed version: ${reqDevCommon}
 		/endm
@@ -90,7 +93,7 @@ Sub MovementInit(bool initSilent,bool requireCommon)
 	/if (!${Defined[initSilent]}) /declare initSilent bool local FALSE
 	
 	/if (!${Defined[devMovementVer]}) {
-		/declare devMovementVer 			float outer 1.73
+		/declare devMovementVer 			float outer 1.74
 		/declare moveCanceled 				bool outer FALSE
 		/declare curLoc 							int outer 0
 		/declare maxMoveTimer 				string outer 5m
@@ -138,15 +141,14 @@ Sub MoveToSpawn(int MoveToID, int StopDistance, bool inCombatMove, bool overRide
 		/mqlog MoveToSpawn:  Spawn ID not found or no ID provided. Aborting... 
 		/return ABORT_NOSPAWN
 	} 
-  /if (!(${Defined[StopDistance]})) { 
+  /if (${StopDistance} == NULL) {
 		/mqlog MoveToSpawn:  Stopping point not defined, using default distance of 20
-    /declare StopDistance int local 
     /varset StopDistance 20
   }
-  /if (!${Defined[inCombatMove]}) /declare inCombatMove bool local FALSE
-	/if (!${Defined[overRideNavigate]}) /declare overRideNavigate bool local FALSE
-	/if (!${Defined[waitForLOS]}) /declare waitForLOS bool local FALSE
-  /if (!${Defined[minimumDistance]}) /declare minimumDistance float local 0
+  /if (${inCombatMove} == NULL) /varset inCombatMove FALSE
+	/if (${overRideNavigate} == NULL) /varset overRideNavigate FALSE
+	/if (${waitForLOS} == NULL) /varset waitForLOS FALSE
+  /if (${minimumDistance} == NULL) /varset minimumDistance 0
   
   /declare running						int local 0
   /declare distanceNow				float local 
@@ -272,13 +274,13 @@ Sub MoveToLoc(float MoveToY, float MoveToX, bool inCombatMove, float MoveToZ, bo
 	/declare useZAxis			bool local
 	/declare moveTimer			timer local
 	
-	/if (!${Defined[inCombatMove]}) /declare inCombatMove bool local false
-	/if (!${Defined[MoveToY]} || !${Defined[MoveToX]}) {
+	/if (${inCombatMove} == NULL) /varset inCombatMove false
+	/if (${MoveToY} == NULL || ${MoveToX} == NULL) {
 		/mqlog The y and or x coordinates were not specified to move to, not attempting movement.
 		/return ABORT_NOCOORDS
 	}
-	/if (!${Defined[MoveToZ]} || ${MoveToZ}==0) {
-		/if (!${Defined[MoveToZ]}) /declare MoveToZ float local 0
+	/if (${MoveToZ} == NULL || ${MoveToZ}==0) {
+		/if (${MoveToZ} == NULL) /varset MoveToZ 0
 		/varset useZAxis FALSE
 		/varset meZ 0
 		/varset moveZ 0
@@ -287,7 +289,7 @@ Sub MoveToLoc(float MoveToY, float MoveToX, bool inCombatMove, float MoveToZ, bo
 		/varset meZ ${Me.Z}
 		/varset moveZ ${MoveToZ}
 	}
-	/if (!${Defined[overRideNavigate]}) /declare overRideNavigate bool local FALSE
+	/if (${overRideNavigate} == NULL) /varset overRideNavigate FALSE
 	
   /varset moveCanceled false
   
@@ -422,9 +424,9 @@ Sub Movement(int Start,int Finish,bool CombatMove,bool ignoreZ,bool fastFace)
 	/declare movePauseTimer	timer local 0s
 	/declare reverseMove		bool local FALSE
 	
-	/if (!${Defined[CombatMove]}) /declare CombatMove bool local FALSE
-	/if (!${Defined[ignoreZ]}) /declare ignoreZ bool local FALSE
-	/if (!${Defined[fastFace]}) /declare fastFace bool local FALSE
+	/if (${CombatMove} == NULL) /varset CombatMove FALSE
+	/if (${ignoreZ} == NULL) /varset ignoreZ FALSE
+	/if (${fastFace} == NULL) /varset fastFace FALSE
 	/if (${curLoc} > ${Finish}) /varset reverseMove TRUE
 	/if (${Me.Feigning} || ${Me.Sitting}) /stand
 	
@@ -529,16 +531,16 @@ Sub Movement(int Start,int Finish,bool CombatMove,bool ignoreZ,bool fastFace)
 	}
 /return ${retValue}
 
-Sub CheckPathExists(PathName,FileName)
-	/if (!${Defined[FileName]}) /declare FileName		string local xxx
+ Sub CheckPathExists(string PathName,string FileName)
+	/if (${FileName.Equal[NULL]}) /varset FileName xxx
 	
 	/call LoadPath ${PathName} ${FileName} FALSE
 /return ${Macro.Return}
 
-Sub LoadPath(PathName,FileName,ReadInPath)
+Sub LoadPath(string PathName,string FileName,bool ReadInPath)
 	/declare fpArray				int local 0
 	/declare pathFound			bool local FALSE
-	/if (!${Defined[ReadInPath]}) /declare ReadInPath		bool local TRUE
+	/if (${ReadInPath} == NULL) /varset ReadInPath TRUE
 	
 	| Attempt to find the path
 	/if (${Defined[FileName]} && ${FileName.NotEqual[NULL]}) {
@@ -567,7 +569,7 @@ Sub LoadPath(PathName,FileName,ReadInPath)
 	/if (!${pathFound}) /call moveLogWrapper "/ag${PathName} /aycould not be found to load."
 /return FALSE
 
-Sub ReadPath(FileName,SectionName)
+Sub ReadPath(string FileName,string SectionName)
 	/declare nValues     	int local 
 	/declare nMArray      int local  0
 	/declare varPrefix		string local Loc
@@ -597,7 +599,7 @@ Sub ReadPath(FileName,SectionName)
 	/varset circularPath ${If[${Math.Distance[${LocArray[1]}:${LocArray[${maxLoc}]}]} < 75,TRUE,FALSE]}
 /return TRUE
 
-Sub ReadINIA(FileName,SectionName)
+Sub ReadINIA(string FileName,string SectionName)
 	/if (${Ini[${FileName},${SectionName},-1,NO].Equal[NO]}) { 
 	  /mqlog "${SectionName}" is not a Valid Section for FILE:${FileName}, ending read
 	  /return 
@@ -622,7 +624,7 @@ Sub SetNearestLoc(bool searchAll)
 	/declare mDistance	int local
 	/declare maLoc		int local
 	/declare miLoc		int local
-	/if (!${Defined[searchAll]}) /declare searchAll bool local false
+	/if (${searchAll} == NULL) /varset searchAll false
 	
 	/varset cDistance 10000
 	/varset cLoc ${curLoc}
@@ -657,7 +659,7 @@ Sub SetFurthestLoc(bool searchAll)
 	/declare mDistance	int local
 	/declare maLoc		int local
 	/declare miLoc		int local
-	/if (!${Defined[searchAll]}) /declare searchAll bool local TRUE
+	/if (${searchAll} == NULL) /varset searchAll TRUE
 	
 	/varset cDistance 0
 	/varset cLoc ${curLoc}
@@ -711,9 +713,9 @@ Sub PositionCheckDefault(float allowedDistance,bool ignorePuller,float maxAllowe
 			/varset pullMode FALSE
 		}
 	}
-	/if (!${Defined[ignorePuller]}) /declare ignorePuller		bool local TRUE
-	/if (!${Defined[allowedDistance]}) /declare allowedDistance		float local ${Math.Calc[${campRadius}*${campReturnRatio}]}
-	/if (!${Defined[maxAllowed]}) /declare maxAllowed				float local 300 
+	/if (${ignorePuller} == NULL) /varset ignorePuller TRUE
+	/if (${allowedDistance} == NULL) /varset allowedDistance ${Math.Calc[${campRadius}*${campReturnRatio}]}
+	/if (${maxAllowed} == NULL) /varset maxAllowed 300 
 	| ${Math.Calc[${allowedDistance} * 3]}
 	/if (${maxAllowed}<${allowedDistance}) /varcalc maxAllowed ${allowDistance}*2
 	/if (!${followMode} && (${ignorePuller} || !${Defined[pullMode]} || !${pullMode}) && ${Math.Distance[${homeY},${homeX}]} > ${allowedDistance}) {
@@ -833,10 +835,10 @@ Sub NavigateToSpawn(int navSpawnID, float stopDistance, bool combatMove, bool wa
 /return NAV_UNKNOWN
 
 Sub SetHome(float newHomeX,float newHomeY,float newHomeZ,float newHomeDir)
-	/if (!${Defined[newHomeX]}) /declare newHomeX float local ${Me.X}
-	/if (!${Defined[newHomeY]}) /declare newHomeY float local ${Me.Y}
-	/if (!${Defined[newHomeZ]}) /declare newHomeZ float local ${Me.Z}
-	/if (!${Defined[newHomeDir]}) /declare newHomeDir float local ${Me.Heading.DegreesCCW}
+	/if (${newHomeX} == NULL) /varset newHomeX ${Me.X}
+	/if (${newHomeY} == NULL) /varset newHomeY ${Me.Y}
+	/if (${newHomeZ} == NULL) /varset newHomeZ ${Me.Z}
+	/if (${newHomeDir} == NULL) /varset newHomeDir ${Me.Heading.DegreesCCW}
 
 	/varset homeX ${newHomeX}
 	/varset homeY ${newHomeY}
@@ -850,8 +852,8 @@ Sub GetHomeDistance
 /return ${homeDistance}
 
 Sub moveLogWrapper(string eMsg, bool logOnly, int msgLevel)
-	/if (!${Defined[logOnly]}) /declare logOnly bool local FALSE
-	/if (!${Defined[msgLevel]}) /declare msgLevel int local 0
+	/if (${logOnly} == NULL) /varset logOnly FALSE
+	/if (${msgLevel} == NULL) /varset msgLevel 0
 	/if (${moveRequireCommon}) {
 		/call EchoLog "${eMsg}" ${logOnly} ${msgLevel}
 	} else {

--- a/devPull.inc
+++ b/devPull.inc
@@ -1,9 +1,12 @@
 | ======================================================================================================
-| 									devPull.inc v1.09
+| 									devPull.inc v1.10
 | 									Written By - Devestator
 | 
 | Description:
 |  devPull is a include file for dev's bots to handle pulling in any situation any class.
+| 
+| v1.10 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.09 Update Notes
 |  -Added PullPathMaxTime and PullPathMaxTimeN to set maximum time for a pull path even if it is still finding mobs
@@ -77,9 +80,9 @@
 |#include pathrecord.mac
 
 Sub PullInit
-	/declare devPullVer						float outer 1.09
-	/declare devPullReqCommon			float outer 2.39
-	/declare devPullReqMovement		float outer 1.69
+	/declare devPullVer						float outer 1.10
+	/declare devPullReqCommon			float outer 2.51
+	/declare devPullReqMovement		float outer 1.74
 
 	/call EchoLog "Initializing devPull.inc v${devPullVer}"	TRUE
 	/if (${devCommonVer}<${devPullReqCommon}) {
@@ -432,7 +435,7 @@ Sub PullCheckGroup
 /return TRUE
 
 Sub PullCheckLocation(float cDist)
-	/if (!${Defined[cDist]}) /declare cDist			float local ${pullRadius}
+	/if (${cDist} == NULL || ${cDist} == 0) /varset cDist ${pullRadius}
 	/declare mobID							int local 0
 	/declare sNum								int local 0
 	/declare nearestPC					int local 0
@@ -492,8 +495,8 @@ Sub PullCombatCheck
 /return
 
 Sub PullLoadPath(string pullLoadPathName, bool changeMode)
-	/if (!${Defined[pullLoadPathName]}) /return FALSE
-	/if (!${Defined[changeMode]}) /declare changeMode bool local TRUE
+	/if (${pullLoadPathName.Equal[NULL]}) /return FALSE
+	/if (${changeMode} == NULL) /varset changeMode TRUE
 	
 	/call EchoLog "Attempting to load pull path ${pullLoadPathName}..." TRUE
 	/if (${pullLoadPathName.Equal[default]}) /varset pullLoadPathName ${Zone.ShortName}
@@ -510,7 +513,7 @@ Sub PullLoadPath(string pullLoadPathName, bool changeMode)
 /return TRUE
 
 Sub PullMob(int pullID)
-	/if (!${Defined[pullID]} || !${pullID} || !${Spawn[${pullID}].ID}) /return FALSE
+	/if (${pullID} == NULL || !${pullID} || !${Spawn[${pullID}].ID}) /return FALSE
 	/declare lullTarg						int local 0
 	/declare lullCount					int local 0
 	/declare lArray							int local 0
@@ -993,7 +996,7 @@ Sub PullWait
 	/declare currID										int local 0
 	/declare currDir									float local 0
 
-	HIGHERDEBUG "PullWait routine started, pullTimeoutTimer: ${pullTimeoutTimer}" TRUE 2
+	HIGHERDEBUG "PullWait routine started, pullTimeoutTimer: ${pullTimeOut}" TRUE 2
 	/if (${faceAtCamp}) /face Heading ${If[${Me.Heading.DegreesCCW}<180,${Math.Calc[${Me.Heading.DegreesCCW} + 180]},${Math.Calc[${Me.Heading.DegreesCCW} - 180]}]}
 	/if (${pullBandolier.NotEqual[NULL]} && ${normalBandolier.NotEqual[NULL]} && ${bandolierAtCamp}) {
 		/delay 5

--- a/druidBot.mac
+++ b/druidBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   DruidBot v1.14
+| 									   DruidBot v1.15
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.15 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.14 Update Notes
 |  -Updates for MQ2 patch changing spell timers to correct healing
@@ -75,27 +78,23 @@
 |#include druidBotSettings.ini
 
 Sub Main(string iniNameStr)
-	/declare meVersion		float outer 1.14
+	/declare meVersion		float outer 1.15
 	/declare myName				string outer druidbot
 	/declare myClass			string outer DRU
 
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon 2.36
-	/varset reqMovement 1.65
+	/varset reqCommon 2.51
+	/varset reqMovement 1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "Druidbot Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName druidBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName druidBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName druidBotSettings.ini
-		}
+		/varset iniName druidBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -161,7 +160,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -241,7 +240,7 @@ Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
 /return ${hMsg}
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local CheckHealTargHPs
+	/if (${hpWatch.Equal[NULL]}) /varset hpWatch CheckHealTargHPs
 	
 	/squelch /target clear
 	/delay 1s !${Target.ID}
@@ -303,7 +302,7 @@ Sub DruidCombatCheck
 
 Sub HealCheck(bool secondaryCall)
 	/if (!${healCount}) /return
-	/if (!${Defined[secondaryCall]}) /declare secondaryCall		bool local FALSE
+	/if (${secondaryCall} == NULL) /varset secondaryCall FALSE
 	/declare hInt					int local 0
 	/declare gPets				bool local FALSE
 	/declare grpArray			int local 0
@@ -630,7 +629,7 @@ Sub LoadSettings
 /return
 
 Sub SecondaryHealCheck(bool gPets)
-	/if (!${Defined[gPets]}) /declare gPets			bool local FALSE
+	/if (${gPets} == NULL) /varset gPets FALSE
 	/declare hInt					int local 0
 	/declare groupAvgHP		int local 0
 	/declare avgCount			int local 0
@@ -744,7 +743,7 @@ Sub SecondaryHealCheck(bool gPets)
 /return COMPLETED
 
 Sub TrackPromise(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -765,7 +764,7 @@ Sub TrackPromise(int playerID, int SpellID)
 /return FALSE
 
 Sub TrackHoT(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	

--- a/enchanterBot.mac
+++ b/enchanterBot.mac
@@ -1,11 +1,14 @@
 | ================================================================================
-|                  			EnchanterBot.Mac v1.22
+|                  			EnchanterBot.Mac v1.23
 |                       Written By: Devestator
 | 
 | USAGE: /macro enchanterbot <iniName>
 | 
 | DESCRIPTION:
 |  Automates the role of an enchanter in the group, including the ability to mez.
+| 
+| v1.23 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.22 Update Notes
 |  -Corrected pet attack using [General] AssistPct instead of [PetSettings] PetAssistPct
@@ -97,7 +100,7 @@
 #event MezBroke "#1#has been awakened by#2#"
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 1.22
+	/declare meVersion									float outer 1.23
 	/declare myName											string outer enchanterbot
 	/declare myClass										string outer ENC
 	/declare currID											int local 0
@@ -107,19 +110,19 @@ Sub main(string iniNameStr)
 	/mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.60
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
-	/if (${Defined[iniNameStr]}) {
-		/varset iniName enchanterbotsettings_${iniNameStr}.ini
-	} else {
-		/varset iniName enchanterbotsettings.ini
-	}
-	
+
 	/call EchoLog "Enchanterbot Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
+		/varset iniName enchanterBotSettings.ini
+	} else {
+		/varset iniName enchanterBotSettings_${iniNameStr}.ini
+	}
+		
 	/call LoadSettings
 	
 	/call EchoLog "Finished loading, starting EnchanterBot v${meVersion}" TRUE
@@ -229,7 +232,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -535,7 +538,7 @@ Sub MezList(string Action, int AddID, string setTimer)
 /return ${hReturn}
 
 Sub MezVerify(int vID)
-	/if (!${Defined[vID]}) /return TRUE
+	/if (${vID} == NULL) /return TRUE
 	/declare retValue					bool local TRUE
 	
 	/call timer attempts ${vID}
@@ -585,7 +588,7 @@ Sub MezVerify(int vID)
 
 Sub MobMoved(int vID, bool UpdateLoc) 
 	/if (!${Spawn[${vID}].ID} || ${Spawn[${vID}].Type.NotEqual[NPC]}) /return FALSE
-	/if (!${Defined[UpdateLoc]}) /declare UpdateLoc bool local FALSE
+	/if (${UpdateLoc} == NULL) /varset UpdateLoc FALSE
 	/declare retValue				bool local FALSE
 	
 	/if (${Defined[mobX${vID}]}) {

--- a/mageBot2.mac
+++ b/mageBot2.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 				MageBot2 (Premium MageBot) v4.17
+| 				MageBot2 (Premium MageBot) v4.18
 | 					Written By Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs
 |  PLUGIN: MQ2Exchange
+| 
+| v4.18 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v4.17 Update Notes
 |  -Made some changes to pet equipping routine to use changes in MQ2 with /itemnotify and /useitem
@@ -131,21 +134,18 @@ Sub Main(string iniNameStr)
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon 2.42
-	/varset reqMovement 1.66
+	/varset reqCommon 2.51
+	/varset reqMovement 1.74
 	/varset debugMode TRUE
 
 	/call EchoLog "MageBot2 Premium Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName mageBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName mageBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName mageBotSettings.ini
-		}
+		/varset iniName mageBotSettings_${iniNameStr}.ini
 	}
+	
 
 	/call LoadSettings
 
@@ -242,7 +242,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 	/declare ePetID			int local 0
@@ -365,7 +365,7 @@ Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
 /return ${hMsg}
 
 Sub EquipPet(int PetID)
-	/if (!${Defined[PetID]}) /declare PetID int local ${Me.Pet.ID}
+	/if (${PetID} == NULL) /varset PetID ${Me.Pet.ID}
 	
 	/if (!${PetID} || !${Spawn[${PetID}].ID} || ${Spawn[${PetID}].Name.Find[familiar]}) /return
 	| /if (!${Me.Pet.ID} || ${Me.Pet.Name.Find[familiar]}) /return
@@ -475,8 +475,8 @@ Sub Event_spellComponent(string line, string stateType, string stateSetting)
 /return
 
 Sub GiveToPet(bool pressGive, int PetID)
-	/if (!${Defined[pressGive]}) /declare pressGive	bool local TRUE
-	/if (!${Defined[PetID]}) /declare PetID int local ${Me.Pet.ID}
+	/if (${pressGive} == NULL) /varset pressGive TRUE
+	/if (${PetID} == NULL) /varset PetID ${Me.Pet.ID}
 	
 	:targetPetLoop
 		/target ID ${PetID}

--- a/monkBot.mac
+++ b/monkBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   MonkBot v1.23
+| 									   MonkBot v1.24
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.24 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.23 Update Notes
 |  -Converted to common target routine
@@ -120,27 +123,23 @@
 #event FDFail "#1# has fallen to the ground."
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 1.23
+	/declare meVersion									float outer 1.24
 	/declare myName											string outer monkbot
 	/declare myClass										string outer MNK
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.65
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "MonkBot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName monkBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName monkBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName monkBotSettings.ini
-		}
+		/varset iniName monkBotSettings_${iniNameStr}.ini
 	}
 	
 	/call LoadSettings
@@ -195,7 +194,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -398,7 +397,7 @@ Sub BurnRoutine
 
 Sub BurnSetUsed(burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	
@@ -416,7 +415,7 @@ Sub BurnSetUsed(burnSet)
 
 Sub BurnSetReady(burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	/declare tAbi								string local NULL

--- a/monkBotSettings.ini
+++ b/monkBotSettings.ini
@@ -33,8 +33,10 @@ DebuffAtStart=FALSE
 PetBuffAtStart=FALSE
 UnsafePCImmediateAction=FALSE
 MinRezAcceptPercent=0
-UseXTarget=FALSE
+UseXTarget=TRUE
 EmuMode=FALSE
+DebugMode=TRUE
+DebugLevel=4
 
 [SelfBuffs]
 SelfBuffName1=Amulet of Necropotence
@@ -87,7 +89,7 @@ MobName16=NULL
 
 [Pull Settings]
 PullAtStart=FALSE
-ReturnToCamp=TRUE
+ReturnToCamp=FALSE
 PullRestTime=0s
 CircuitRestTime=1m
 Lull=Phantasmal Apparition

--- a/necroBot.mac
+++ b/necroBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   NecroBot v1.16
+| 									   NecroBot v1.17
 | 									Written By: Devestator
 | 													
 | 													
@@ -19,6 +19,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.17 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.16 Update Notes
 |  -Converted to common target routine
@@ -91,7 +94,7 @@
 #event petGuard "#*#Guarding with my life..oh splendid one.#*#"
 
 Sub Main(string iniNameStr)
-	/declare meVersion		float outer 1.16
+	/declare meVersion		float outer 1.17
 	/declare myName				string outer necrobot
 	/declare myClass			string outer NEC
 	/declare resumeFollow	bool local FALSE
@@ -99,21 +102,18 @@ Sub Main(string iniNameStr)
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.65
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode TRUE
 	
 	/call EchoLog "Necrobot Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName necroBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName necroBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName necroBotSettings.ini
-		}
+		/varset iniName necroBotSettings_${iniNameStr}.ini
 	}
+	
 	
 	/call LoadSettings
 	
@@ -211,7 +211,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -293,8 +293,8 @@ Sub Event_pFocusOff
 /return
 
 Sub FDRoutine(string fdTime,string standCondition)
-	/if (!${Defined[fdTime]}) /declare fdTime			string local 0s
-	/if (!${Defined[standCondition]}) /declare standCondition	string local Math.Calc[1] 
+	/if (${fdTime.Equal[NULL]}) /varset fdTime 0s
+	/if (${standCondition.Equal[NULL]}) /varset standCondition Math.Calc[1] 
 	/declare fdTimer			timer local 0s
 	/if (${fdTime.NotEqual[0s]} || ${Me.PctHPs} < ${FDHP} || (${lTargCount} > 1 && ${Spawn[${mainTank}].PctHPs} < 20 && ${mainTank.NotEqual[NULL]}) || (${lTargCount}==1 && (${Spawn[${mainTank}].Type.Equal[Corpse]} || !${Spawn[${mainTank}].ID}) && ${mainTank.NotEqual[NULL]})) {
 		/if (${Me.Feigning}) /stand
@@ -683,7 +683,7 @@ Sub PullMobSolo(int pullID)
 
 Sub Resting(string sforceRestTime)
 	/varset sitTimer 0s
-	/if (!${Defined[sforceRestTime]}) /declare sforceRestTime string local 0s
+	/if (${sforceRestTime.Equal[NULL]}) /varset sforceRestTime 0s
 	/declare forceRestTime 	timer local ${sforceRestTime}
 	/declare reasonHP	bool local
 	/varset rested FALSE
@@ -759,8 +759,8 @@ Sub Resting(string sforceRestTime)
 /return
 
 Sub SnareTrack(int mobID,bool AddTrack,string trackLength)
-	/if (!${Defined[AddTrack]}) /declare AddTrack					bool local FALSE
-	/if (!${Defined[trackLength]}) /declare trackLength		string local ${Math.Calc[${Spell[${kiteSnareSpell}].Duration.TotalSeconds} - 20]}s
+	/if (${DAddTrack} == NULL) /varset AddTrack FALSE
+	/if (${trackLength.Equal[NULL]}) /declare trackLength ${Math.Calc[${Spell[${kiteSnareSpell}].Duration.TotalSeconds} - 20]}s
 	/if (${AddTrack}) {
 		/if (!${Defined[snareTrack${mobID}]}) /declare snareTrack${mobID}			timer outer 0s
 		/varset snareTrack${mobID} ${trackLength}
@@ -881,7 +881,7 @@ Sub SoloMoveAhead
 /return
 
 Sub SoloPositionCheck(float distanceCheck)
-	/if (!${Defined[distanceCheck]}) /declare distanceCheck				float local ${Math.Calc[${kiteMoveRadius} - ${kiteMoveRadius} / 3]}
+	/if (${distanceCheck} == NULL) /varset distanceCheck ${Math.Calc[${kiteMoveRadius} - ${kiteMoveRadius} / 3]}
 	/for nArray 1 to ${targCount}
 		/if (${targArray[${nArray}]} && ${Spawn[${targArray[${nArray}]}].ID} && ${Spawn[${targArray[${nArray}]}].Type.NotEqual[Corpse]}) {
 			/if (${Spawn[${targArray[${nArray}]}].Distance} < ${distanceCheck}) {

--- a/paladinBot.mac
+++ b/paladinBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   PaladinBot v1.07
+| 									   PaladinBot v1.08
 | 									Written By: Devestator						
 | 													
 | 													
@@ -20,6 +20,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.08 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.07 Update Notes
 |  -Added ability to combat npc pets
@@ -51,29 +54,26 @@
 #event tooFarTaunt "You are too far away from your target to taunt."
 
 Sub main(string iniNameStr, string groupRoleStr)
-	/declare meVersion									float outer 1.07
+	/declare meVersion									float outer 1.08
 	/declare myName											string outer paladinbot
 	/declare myClass										string outer PAL
 	/declare groupRoleSet	bool outer FALSE
 	
 	/squelch /mqlog clear
 	/call CommonInit
-	/varset reqCommon 2.36
-	/varset reqMovement 1.60
+	/varset reqCommon 2.51
+	/varset reqMovement 1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "PaladinBot v${meVersion} Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName paladinBotSettings.ini
 	} else {
-		/if (${iniNameStr.NotEqual[default]}) {
-			/varset iniName paladinBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName paladinBotSettings.ini
-		}
+		/varset iniName paladinBotSettings_${iniNameStr}.ini
 	}
-	/if (${Defined[groupRoleStr]}) {
+	
+	/if (${groupRoleStr.NotEqual[NULL]}) {
 		/varset groupRoleSet TRUE
 		/varset groupRole ${groupRoleStr}
 	} else {
@@ -338,7 +338,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom, string rMsg, bool fromEQBC)
-/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -642,7 +642,7 @@ Sub MezCheck(int mobID)
 /return ${retValue}
 
 Sub AggroCheckTarg(int mobID)
-	/if (!${Defined[mobID]}) /return true
+	/if (${mobID} == NULL) /return true
 	/if (${Spawn[ID ${mobID}].Type.NotEqual[NPC]}) /return true
 	/declare mobHeading				Float local
 	/declare mobToMeHeading		Float local
@@ -699,7 +699,7 @@ Sub Event_tooFarTaunt
 
 Sub HealCheck(bool secondaryCall)
 	/if (!${healCount}) /return
-	/if (!${Defined[secondaryCall]}) /declare secondaryCall		bool local FALSE
+	/if (${secondaryCall} == NULL) /varset secondaryCall FALSE
 	/declare hInt					int local 0
 	/declare gPets				bool local false
 	/declare grpArray			int local 0
@@ -847,7 +847,7 @@ Sub HealCheck(bool secondaryCall)
 /return
 
 Sub SecondaryHealCheck(bool gPets)
-	/if (!${Defined[gPets]}) /declare gPets			bool local FALSE
+	/if (${gPets} == NULL) /varset gPets FALSE
 	/declare hInt					int local 0
 	/declare groupAvgHP		int local 0
 	/declare avgCount			int local 0
@@ -962,9 +962,9 @@ Sub SecondaryHealCheck(bool gPets)
 /return COMPLETED
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[healTargID]} || !${healTargID}) /return
+	/if (${healTargID} == NULL || !${healTargID}) /return
 	/declare sMaxTry				int local ${resistTries}
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local EmergencyHeal
+	/if (${hpWatch.Equal[NULL]}) /varset hpWatch EmergencyHeal
 	
 	/if (${Me.Casting.ID} && ${allowInterrupt}) /call Interrupt
 	/varset currHealID ${Spell[${healSpell[${healNum}]}].ID}
@@ -1028,7 +1028,7 @@ Sub EmergencyHeal
 /return
 
 Sub TrackPromise(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -1049,7 +1049,7 @@ Sub TrackPromise(int playerID, int SpellID)
 /return FALSE
 
 Sub TrackHoT(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	

--- a/pathrecord.mac
+++ b/pathrecord.mac
@@ -17,9 +17,9 @@ Sub main(string pName, string iName, bool rZ)
 	/declare recordZ			bool outer TRUE
 	/declare zoneStr			strin local
 	
-	/if (${Defined[pName]}) /varset pathName ${pName}
-	/if (${Defined[iName]}) /varset iniName ${iName}
-	/if (${Defined[rZ]}) /varset recordZ ${rZ}
+	/if (${pName.NotEqual[NULL]}) /varset pathName ${pName}
+	/if (${iName.NotEuqal[NULL]}) /varset iniName ${iName}
+	/if (${rZ} != NULL) /varset recordZ ${rZ}
 	
 	/if (${iniName.Equal[default]} || ${iniName.Equal[NULL]}) /varset iniName Path.ini
 	/if (!${iniName.Find[.ini]}) /varset iniName ${iniName}.ini

--- a/rangerBot.mac
+++ b/rangerBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   RangerBot v1.12
+| 									   RangerBot v1.13
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.13 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.12 Update Notes
 |  -Moved ranger general settings from [General] to [Ranger_General].  These settings will default to
@@ -69,28 +72,25 @@
 |#include rangerBotSettings.ini
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 1.12
+	/declare meVersion									float outer 1.13
 	/declare myName											string outer rangerbot
 	/declare myClass										string outer RNG
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.65
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "RangerBot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName rangerBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName rangerBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName rangerBotSettings.ini
-		}
+		/varset iniName rangerBotSettings_${iniNameStr}.ini
 	}
+	
 	
 	/call LoadSettings
 	
@@ -128,7 +128,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -379,7 +379,7 @@ Sub LoadSettings
 /return
 
 Sub RangerCombatCheck(bool AddCheck)
-	/if (!${Defined[AddCheck]}) /declare AddCheck				bool local TRUE
+	/if (${AddCheck} == NULL) /varset AddCheck TRUE
 	/if (${AddCheck}) /call CheckForAdds ${campRadius} ${Me.ID} false true
 	/if (!${inCombat} && (${lTargCount} > 0 || ${Me.CombatState.Equal[Combat]})) {
 		/if (${Me.Sitting}) /stand
@@ -422,11 +422,10 @@ Sub HealCheck
 /return
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[healTargID]} || !${healTargID}) /return
+	/if (${healTargID} == NULL || !${healTargID}) /return
 	/declare sMaxTry				int local ${resistTries}
 	/declare currHealID 		int local 0
 	/declare beforeCastID		int local 0
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local NULL
 	
 	/if (${Me.Casting.ID} && ${allowInterrupt}) /call Interrupt
 	|/varset currHealID ${Spell[${healSpell[${healNum}]}].ID}

--- a/rogueBot.mac
+++ b/rogueBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   RogueBot v1.24
+| 									   RogueBot v1.25
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.25 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.24 Update Notes
 |  -Added hidden setting [Combat] SneakAttackTimeout=30s.  This will set how long the rogue will wait
@@ -91,28 +94,25 @@
 #event EvadeFail "Your attempts at ducking clear of combat fail."
 
 Sub main(string iniNameStr)
-	/declare meVersion									float outer 1.24
+	/declare meVersion									float outer 1.25
 	/declare myName											string outer roguebot
 	/declare myClass										string outer ROG
 
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.65
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "RogueBot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName rogueBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName rogueBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName rogueBotSettings.ini
-		}
+		/varset iniName rogueBotSettings_${iniNameStr}.ini
 	}
+	
 	
 	/call LoadSettings
 	
@@ -161,7 +161,7 @@ Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
 	/declare bcArray		int local 0
 	| /declare burnAlias	string local NULL
 	/declare mReturn		int local 0
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 	/declare burnArray	int local 0
@@ -637,7 +637,7 @@ Sub LoadSettings
 /return
 
 Sub RogueCombatCheck(bool AddCheck)
-	/if (!${Defined[AddCheck]}) /declare AddCheck				bool local TRUE
+	/if (${AddCheck} == NULL) /varset AddCheck TRUE
 	/if (${AddCheck}) /call CheckForAdds ${campRadius} ${Me.ID} false true
 	/if (!${inCombat} && (${lTargCount} > 0 || ${Me.CombatState.Equal[Combat]})) {
 		/if (${Me.Sitting}) /stand
@@ -740,9 +740,9 @@ Sub BurnRoutine
 /return
 
 
-Sub BurnSetUsed(burnSet)
+Sub BurnSetUsed(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	
@@ -758,9 +758,9 @@ Sub BurnSetUsed(burnSet)
 	/next bSetArray	
 /return FALSE
 
-Sub BurnSetReady(burnSet)
+Sub BurnSetReady(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	/declare tAbi								string local NULL

--- a/shamanBot.mac
+++ b/shamanBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   ShamanBot v1.24
+| 									   ShamanBot v1.25
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.25 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.24 Update Notes
 |  -Corrected typo on Dimnuitive Companion AA cast, it should not correctly use it to shrink pets if configure to.
@@ -124,28 +127,25 @@
 |#include shamanBotSettings.ini
 
 Sub Main(string iniNameStr)
-	/declare meVersion									float outer 1.24
+	/declare meVersion									float outer 1.25
 	/declare myName											string outer shamanbot
 	/declare myClass										string outer SHM
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.60
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "Shamanbot v${meVersion} Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName shamanBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName shamanBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName shamanBotSettings.ini
-		}
+		/varset iniName shamanBotSettings_${iniNameStr}.ini
 	}
+	
 	
 	/call LoadSettings
 	
@@ -201,7 +201,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -320,9 +320,9 @@ Sub CanniCheck
 /return
 
 Sub CastHeal(int healNum, int healTargID, string hpWatch)
-	/if (!${Defined[healTargID]} || !${healTargID}) /return
+	/if (${healTargID} == NULL || !${healTargID}) /return
 	/declare sMaxTry				int local ${resistTries}
-	/if (!${Defined[hpWatch]}) /declare hpWatch string local EmergencyHeal
+	/if (${hpWatch.Equal[NULL]}) /declare hpWatch string local EmergencyHeal
 	
 	/if (${Me.Casting.ID} && ${allowInterrupt}) /call Interrupt
 	/varset currHealID ${Spell[${healSpell[${healNum}]}].ID}
@@ -517,7 +517,7 @@ Sub DuckHeal
 
 Sub HealCheck(bool secondaryCall)
 	/if (!${healCount}) /return
-	/if (!${Defined[secondaryCall]}) /declare secondaryCall		bool local FALSE
+	/if (${secondaryCall} == NULL) /varset secondaryCall FALSE
 	/declare hInt					int local 0
 	/declare gPets				bool local false
 	/declare grpArray			int local 0
@@ -693,7 +693,7 @@ Sub HealCheck(bool secondaryCall)
 /return
 
 Sub SecondaryHealCheck(bool gPets)
-	/if (!${Defined[gPets]}) /declare gPets			bool local FALSE
+	/if (${gPets} == NULL) /varset gPets FALSE
 	/declare hInt					int local 0
 	/declare groupAvgHP		int local 0
 	/declare avgCount			int local 0
@@ -1077,7 +1077,7 @@ Sub ShamanCombatCheck
 /return
 
 Sub TrackHoT(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -1098,7 +1098,7 @@ Sub TrackHoT(int playerID, int SpellID)
 /return FALSE
 
 Sub TrackPromise(int playerID, int SpellID)
-	/if (!${Defined[playerID]}) /return
+	/if (${playerID} == NULL) /return
 	/declare pLoop					int local 0
 	/declare pInt						int local 0 
 	
@@ -1122,7 +1122,7 @@ Sub ShrinkCheck(string charName)
 	/declare shrinkNeeded						bool local FALSE
 	/declare groupHasPets						bool local FALSE
 	/declare shrinkItem							string local NULL
-	/if (!${Defined[charName]}) {
+	/if (${charName.Equal[NULL]}) {
 		/if (${useGroupShrink} && (${Me.Book[Tiny Terror]} || ${Me.AltAbilityReady[Group Shrink]}) && ${Group.Members}) {
 			:castGroupShrink
 				/varset shrinkNeeded FALSE

--- a/skBot2.mac
+++ b/skBot2.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   SkBot v2.15
+| 									   SkBot v2.16
 | 									Written By: Devestator						
 | 													
 | 													
@@ -20,6 +20,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v2.16 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v2.15 Update Notes
 |  -Corrected missing stand check after SK fds.
@@ -88,29 +91,26 @@
 #event petHoldChange "The pet hold mode has been set to #1#."
 
 Sub main(string iniNameStr, string groupRoleStr)
-	/declare meVersion									float outer 2.15
+	/declare meVersion									float outer 2.16
 	/declare myName											string outer skbot2
 	/declare myClass										string outer SHD
 	/declare groupRoleSet	bool outer FALSE
 	
 	/squelch /mqlog clear
 	/call CommonInit
-	/varset reqCommon 2.36
-	/varset reqMovement 1.60
+	/varset reqCommon 2.51
+	/varset reqMovement 1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "Skbot v${meVersion} Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName skBotSettings.ini
 	} else {
-		/if (${iniNameStr.NotEqual[default]}) {
-			/varset iniName skBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName skBotSettings.ini
-		}
+		/varset iniName skBotSettings_${iniNameStr}.ini
 	}
-	/if (${Defined[groupRoleStr]}) {
+	
+	/if (${groupRoleStr.NotEqual[NULL]}) {
 		/varset groupRoleSet TRUE
 		/varset groupRole ${groupRoleStr}
 	} else {
@@ -433,7 +433,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom, string rMsg, bool fromEQBC)
-/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -723,7 +723,7 @@ Sub SummonPet
 /return
 
 Sub AggroCheckTarg(int mobID)
-	/if (!${Defined[mobID]}) /return true
+	/if (${mobID} == NULL) /return true
 	/if (${Spawn[ID ${mobID}].Type.NotEqual[NPC]}) /return true
 	/declare mobHeading				Float local
 	/declare mobToMeHeading		Float local

--- a/warriorBot.mac
+++ b/warriorBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 					WarriorBot v1.10
+| 					WarriorBot v1.11
 | 						Written By: Devestator
 | 													
 | 													
@@ -20,6 +20,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.11 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.10 Update Notes
 |  -Added some distance checks to the combat target selection to prevent warrior from running off after targets really
@@ -67,29 +70,26 @@
 #event failedTaunt "You are too far away from your target to taunt."
 
 Sub main(string iniNameStr, string groupRoleStr)
-	/declare meVersion								float outer 1.10
+	/declare meVersion								float outer 1.11
 	/declare myName										string outer warriorbot
 	/declare myClass									string outer WAR
 	/declare groupRoleSet							bool outer FALSE
 	
 	/squelch /mqlog clear
 	/call CommonInit
-	/varset reqCommon 2.36
-	/varset reqMovement 1.65
+	/varset reqCommon 2.51
+	/varset reqMovement 1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "WarriorBot v${meVersion} Initialized" TRUE
 	/call EchoLog "Loading variables..." TRUE
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName warriorBotSettings.ini
 	} else {
-		/if (${iniNameStr.NotEqual[default]}) {
-			/varset iniName warriorBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName warriorBotSettings.ini
-		}
+		/varset iniName warriorBotSettings_${iniNameStr}.ini
 	}
-	/if (${Defined[groupRoleStr]}) {
+	
+	/if (${groupRoleStr.NotEqual[NULL]}) {
 		/varset groupRoleSet TRUE
 		/varset groupRole ${groupRoleStr}
 	} else {
@@ -420,7 +420,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom, string rMsg, bool fromEQBC)
-/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -676,9 +676,9 @@ Sub HealthCheck
 /return
 
 Sub AggroCheckTarg(int mobID,int targArrayIndex)
-	/if (!${Defined[mobID]}) /return TRUE
+	/if (${mobID} == NULL) /return TRUE
 	/if (${Spawn[ID ${mobID}].Type.NotEqual[NPC]} && (${Spawn[ID ${mobID}].Type.NotEqual[Pet]} || ${Spawn[ID ${mobID}].Master.Type.Equal[PC]})) /return TRUE
-	/if (!${Defined[targArrayIndex]}) /declare targArrayIndex		int local 0
+	/if (${targArrayIndex} == NULL) /varset targArrayIndex 0
 	
 	/declare mobHeading				Float local
 	/declare mobToMeHeading		Float local

--- a/wizardBot.mac
+++ b/wizardBot.mac
@@ -1,5 +1,5 @@
 | =================================================================================================
-| 									   WizardBot v1.12
+| 									   WizardBot v1.13
 | 									Written By: Devestator
 | 													
 | 													
@@ -18,6 +18,9 @@
 |  PLUGIN: MQ2Cast
 |  PLUGIN: MQ2Debuffs													
 |  PLUGIN: MQ2Exchange
+| 
+| v1.13 Update Notes
+|  -Updated for 09082017 MQ2 Patch that makes a lot of changes with undefined variables and breaks function calls relying on Not defined to set defaults
 | 
 | v1.12 Update Notes
 |  -Corrected a problem with combat routines running even when out of combat
@@ -68,28 +71,25 @@
 |#include wizardBotSettings.ini
 
 Sub Main(string iniNameStr)
-	/declare meVersion		float outer 1.12
+	/declare meVersion		float outer 1.13
 	/declare myName				string outer wizardbot
 	/declare myClass			string outer WIZ
 	
 	/squelch /mqlog clear
 	
 	/call CommonInit
-	/varset reqCommon	2.36
-	/varset reqMovement  1.60
+	/varset reqCommon	2.51
+	/varset reqMovement  1.74
 	/varset debugMode FALSE
 	
 	/call EchoLog "Wizardbot Initialized" true
 	/call EchoLog "Loading variables..." true
-	/if (!${Defined[iniNameStr]}) {
+	/if (${iniNameStr.Equal[NULL]} || ${iniNameStr.Equal[default]}) {
 		/varset iniName wizardBotSettings.ini
 	} else {
-		/if (!${iniNameStr.Equal[default]}) {
-			/varset iniName wizardBotSettings_${iniNameStr}.ini
-		} else {
-			/varset iniName wizardBotSettings.ini
-		}
+		/varset iniName wizardBotSettings_${iniNameStr}.ini
 	}
+	
 	
 	/call LoadSettings
 	
@@ -172,7 +172,7 @@ Sub AfterDeath
 /return
 
 Sub BotCommands(string rFrom,string rMsg, bool fromEQBC)
-	/if (!${Defined[fromEQBC]}) /declare fromEQBC			local FALSE
+	/if (${fromEQBC} == NULL) /varset fromEQBC FALSE
 	/declare hMsg				string local COMPLETED_NOTFOUND
 	/declare rFromID		int local 0
 
@@ -520,9 +520,9 @@ Sub BurnRoutine
 /return
 
 
-Sub BurnSetUsed(burnSet)
+Sub BurnSetUsed(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	
@@ -538,9 +538,9 @@ Sub BurnSetUsed(burnSet)
 	/next bSetArray	
 /return FALSE
 
-Sub BurnSetReady(burnSet)
+Sub BurnSetReady(int burnSet)
 	/if (!${burnSetCount}) /return FALSE
-	/if (!${Defined[burnSet]}) /return FALSE
+	/if (${burnSet} == NULL) /return FALSE
 	/declare bSetArray					int local 0
 	/declare bAbiArray					int local 0
 	/declare tAbi								string local NULL


### PR DESCRIPTION
Updates for the 09082017 MQ2 patch dealing with undeclared variables.  Mostly causing problems with function variables that could previously be checked for being undefined to set a default, now had to be checked for being NULL instead.